### PR TITLE
Add `--replace` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ Syntax:
 $ xk6 build [<k6_version>]
     [--output <file>]
     [--with <module[@version][=replacement]>...]
+    [--replace <module=replacement>...]
 ```
 
 - `<k6_version>` is the core k6 version to build; defaults to `K6_VERSION` env variable or latest.
 - `--output` changes the output file.
 - `--with` can be used multiple times to add extensions by specifying the Go module name and optionally its version, similar to `go get`. Module name is required, but specific version and/or local replacement are optional.
+- `--replace` can be used multiple times to add replacements by specifying the Go module name and the replacement module, similar to `go mod edit -replace=`. Version of the replacement can be specified with the `@version` suffix in the replacement path.
 
 Examples:
 

--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -88,14 +88,14 @@ func runBuild(ctx context.Context, args []string) error {
 			}
 			i++
 			mod, _, repl, err := splitWith(args[i])
-
 			if err != nil {
 				return err
 			}
 			if repl == "" {
 				return fmt.Errorf("replace value must be of format 'module=replace' or 'module=replace@version'")
 			}
-			mod = strings.TrimSuffix(mod, "/") // easy to accidentally leave a trailing slash if pasting from a URL, but is invalid for Go modules
+			// easy to accidentally leave a trailing slash if pasting from a URL, but is invalid for Go modules
+			mod = strings.TrimSuffix(mod, "/")
 			repl, err = expandPath(repl)
 			if err != nil {
 				return err

--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -88,10 +88,11 @@ func runBuild(ctx context.Context, args []string) error {
 			}
 			i++
 			mod, _, repl, err := splitWith(args[i])
+
 			if err != nil {
 				return err
 			}
-			if repl != "" {
+			if repl == "" {
 				return fmt.Errorf("replace value must be of format 'module=replace' or 'module=replace@version'")
 			}
 			mod = strings.TrimSuffix(mod, "/") // easy to accidentally leave a trailing slash if pasting from a URL, but is invalid for Go modules
@@ -289,22 +290,19 @@ func trapSignals(ctx context.Context, cancel context.CancelFunc) {
 func splitWith(arg string) (module, version, replace string, err error) {
 	const versionSplit, replaceSplit = "@", "="
 
-	parts := strings.SplitN(arg, versionSplit, 2)
+	parts := strings.SplitN(arg, replaceSplit, 2)
+	if len(parts) > 1 {
+		replace = parts[1]
+	} else {
+		replace = ""
+	}
+
 	module = parts[0]
 
-	if len(parts) == 1 {
-		parts := strings.SplitN(module, replaceSplit, 2)
-		if len(parts) > 1 {
-			module = parts[0]
-			replace = parts[1]
-		}
-	} else {
-		version = parts[1]
-		parts := strings.SplitN(version, replaceSplit, 2)
-		if len(parts) > 1 {
-			version = parts[0]
-			replace = parts[1]
-		}
+	moduleParts := strings.SplitN(module, versionSplit, 2)
+	if len(moduleParts) > 1 {
+		module = moduleParts[0]
+		version = moduleParts[1]
 	}
 
 	if module == "" {

--- a/cmd/xk6/main_test.go
+++ b/cmd/xk6/main_test.go
@@ -35,6 +35,12 @@ func TestSplitWith(t *testing.T) {
 			expectReplace: "replace",
 		},
 		{
+			input:         "module@module_version=replace@replace_version",
+			expectModule:  "module",
+			expectReplace: "replace@replace_version",
+			expectVersion: "module_version",
+		},
+		{
 			input:     "=replace",
 			expectErr: true,
 		},

--- a/cmd/xk6/main_test.go
+++ b/cmd/xk6/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -123,4 +124,39 @@ func TestNormalizeImportPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExpandPath(t *testing.T) {
+	t.Run(". expands to current directory", func(t *testing.T) {
+		got, err := expandPath(".")
+		if got == "." {
+			t.Errorf("did not expand path")
+		}
+		if err != nil {
+			t.Errorf("failed to expand path")
+		}
+	})
+	t.Run("~ expands to user's home directory", func(t *testing.T) {
+		got, err := expandPath("~")
+		if got == "~" {
+			t.Errorf("did not expand path")
+		}
+		if err != nil {
+			t.Errorf("failed to expand path")
+		}
+		switch runtime.GOOS {
+		case "linux":
+			if !strings.HasPrefix(got, "/home") {
+				t.Errorf("did not expand home directory. want=/home/... got=%s", got)
+			}
+		case "darwin":
+			if !strings.HasPrefix(got, "/Users") {
+				t.Errorf("did not expand home directory. want=/Users/... got=%s", got)
+			}
+		case "windows":
+			if !strings.HasPrefix(got, "C:\\Users") { // could well be another drive letter, but let's assume C:\\
+				t.Errorf("did not expand home directory. want=C:\\Users\\... got=%s", got)
+			}
+		}
+	})
 }


### PR DESCRIPTION
`--replace` can be used multiple times to add replacements by specifying
the Go module name and the replacement module, similar to `go mod edit
-replace=`. Version of the replacement can be specified with the
`@version` suffix in the replacement path.

Fixes #32 

Signed-off-by: Christian Haudum <christian.haudum@gmail.com>