### PR TITLE
Forcing compat 1.17 version for gomod

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -94,7 +94,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	log.Println("[INFO] Building k6")
 
 	// tidy the module to ensure go.mod and go.sum are consistent with the module prereq
-	tidyCmd := buildEnv.newCommand("go", "mod", "tidy")
+	tidyCmd := buildEnv.newCommand("go", "mod", "tidy", "-compat=1.17")
 	if err := buildEnv.runCommand(ctx, tidyCmd, b.TimeoutGet); err != nil {
 		return err
 	}

--- a/environment.go
+++ b/environment.go
@@ -260,7 +260,7 @@ func (env environment) execGoModRequire(ctx context.Context, modulePath, moduleV
 		return err
 	}
 	// tidy the module to ensure go.mod will not have versions such as `latest`
-	tidyCmd := env.newCommand("go", "mod", "tidy")
+	tidyCmd := env.newCommand("go", "mod", "tidy", "-compat=1.17")
 	return env.runCommand(ctx, tidyCmd, env.timeoutGoGet)
 }
 


### PR DESCRIPTION
It forces the builder to use the `go mod tidy -compat=1.17` version in the case of conflict resolution.

Should we add a way for the user of declaring to use the 1.16 version?