### PR TITLE
Provide an end-of-build message

### DIFF
--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -56,6 +56,7 @@ func main() {
 func runBuild(ctx context.Context, args []string) error {
 	// parse the command line args... rather primitively
 	var argK6Version, output string
+	var outputOverride bool
 	var extensions []xk6.Dependency
 	var replacements []xk6.Replace
 	for i := 0; i < len(args); i++ {
@@ -108,6 +109,7 @@ func runBuild(ctx context.Context, args []string) error {
 			}
 			i++
 			output = args[i]
+			outputOverride = true
 
 		default:
 			if argK6Version != "" {
@@ -160,14 +162,12 @@ func runBuild(ctx context.Context, args []string) error {
 		}
 	}
 
-	fmt.Println("***************************************************")
-	fmt.Println("* BUILD COMPLETE - FOLLOW THESE STEPS TO CONTINUE *")
-	fmt.Println("***************************************************")
-	fmt.Println("xk6 has now produced a new k6 binary with the following:")
-	for _, extension := range extensions {
-		fmt.Println(" -", extension.PackagePath)
+	if !outputOverride {
+		path, _ := os.Getwd()
+		fmt.Println()
+		fmt.Println("xk6 has now produced a new k6 binary which may be different than the command on your system path!")
+		fmt.Printf("Be sure to run '%v run <SCRIPT_NAME>' from the '%v' directory.\n", output, path)
 	}
-	fmt.Printf("To use it, call it directly as `%v run <SCRIPT_NAME>`.\n", output)
 
 	return nil
 }

--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -160,6 +160,15 @@ func runBuild(ctx context.Context, args []string) error {
 		}
 	}
 
+	fmt.Println("***************************************************")
+	fmt.Println("* BUILD COMPLETE - FOLLOW THESE STEPS TO CONTINUE *")
+	fmt.Println("***************************************************")
+	fmt.Println("xk6 has now produced a new k6 binary with the following:")
+	for _, extension := range extensions {
+		fmt.Println(" -", extension.PackagePath)
+	}
+	fmt.Printf("To use it, call it directly as `%v run <SCRIPT_NAME>`.\n", output)
+
 	return nil
 }
 


### PR DESCRIPTION
Addresses issue #38.

Example output:
<img width="572" alt="image" src="https://user-images.githubusercontent.com/944496/158853685-7e8a2180-fc61-4dd4-b0bb-5d4bf3442344.png">

I didn't add the output to the `log`, preferring plain stdout. WDYT? Timestamps and level just seemed superfluous.