### PR TITLE
Don't force latest k6 when building extensions

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -118,9 +118,13 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 	log.Println("[INFO] Pinning versions")
 	if b.K6Repo == "" {
 		// building with the default main repo
-		err = env.execGoModRequire(ctx, k6ModulePath, env.k6Version)
-		if err != nil {
-			return nil, err
+		if env.k6Version != "" {
+			// don't actually specify k6 version if it wasn't specified
+			// the extension(s) will require a version that they work with either way
+			err = env.execGoModRequire(ctx, k6ModulePath, env.k6Version)
+			if err != nil {
+				return nil, err
+			}
 		}
 	} else {
 		// building with a forked repo, so get the main one and replace it with

--- a/environment.go
+++ b/environment.go
@@ -108,17 +108,7 @@ func (b Builder) newEnvironment(ctx context.Context) (*environment, error) {
 
 	// pin versions by populating go.mod, first for k6 itself and then extensions
 	log.Println("[INFO] Pinning versions")
-	if b.K6Repo == "" {
-		// building with the default main repo
-		if env.k6Version != "" {
-			// don't actually specify k6 version if it wasn't specified
-			// the extension(s) will require a version that they work with either way
-			err = env.execGoModRequire(ctx, k6ModulePath, env.k6Version)
-			if err != nil {
-				return nil, err
-			}
-		}
-	} else {
+	if b.K6Repo != "" {
 		// building with a forked repo, so get the main one and replace it with
 		// the fork
 		err = env.execGoModRequire(ctx, k6ModulePath, "")
@@ -175,6 +165,18 @@ nextExt:
 		return nil, err
 	}
 
+	// building with the default main repo
+	if b.K6Repo == "" && env.k6Version != "" {
+		// don't actually specify k6 version if it wasn't specified
+		// the extension(s) will require a version that they work with either way
+		// but if it was let specify it now
+		// all the previous steps should've worked so far as the extensions themselves would've required
+		// specific versions to begin with and they should work with those versions
+		err = env.execGoModRequire(ctx, k6ModulePath, env.k6Version)
+		if err != nil {
+			return nil, err
+		}
+	}
 	err = env.execGoModTidy(ctx)
 	if err != nil {
 		return nil, err

--- a/environment.go
+++ b/environment.go
@@ -167,11 +167,9 @@ nextExt:
 
 	// building with the default main repo
 	if b.K6Repo == "" && env.k6Version != "" {
-		// don't actually specify k6 version if it wasn't specified
-		// the extension(s) will require a version that they work with either way
-		// but if it was let specify it now
-		// all the previous steps should've worked so far as the extensions themselves would've required
-		// specific versions to begin with and they should work with those versions
+		// Only require a specific k6 version if provided. Otherwise extensions
+		// will require a version they depend on, and Go's module resolution
+		// algorithm will choose the highest one among all extensions.
 		err = env.execGoModRequire(ctx, k6ModulePath, env.k6Version)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
an extension will always require k6 and a version of it. It makes little
sense to force newer version on users especially as we keep breaking
them and we need time to go fix them, but that can only happen after
release.

This still lets users specify the version (as latest for example) and
require the latest k6, it just isn't the default.