### PR TITLE
fix: library usage sample in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ The race detector can be enabled by setting `XK6_RACE_DETECTOR=1`.
 
 ```go
 builder := xk6.Builder{
-	k6Version: "v0.35.0",
+	K6Version: "v0.35.0",
 	Extensions: []xk6.Dependency{
 		{
-			ModulePath: "github.com/grafana/xk6-browser",
-			Version:    "v0.1.1",
+			PackagePath: "github.com/grafana/xk6-browser",
+			Version:     "v0.1.1",
 		},
 	},
 }

--- a/builder.go
+++ b/builder.go
@@ -139,7 +139,7 @@ type Dependency struct {
 	// The name (import path) of the Go package. If at a version > 1,
 	// it should contain semantic import version (i.e. "/v2").
 	// Used with `go get`.
-	PackagePath string `json:"module_path,omitempty"`
+	PackagePath string `json:"package_path,omitempty"`
 
 	// The version of the Go module, as used with `go get`.
 	Version string `json:"version,omitempty"`


### PR DESCRIPTION
Hello, grafana's engineering team!
I have used grafana, k6, etc. and they have been very helpful.

I fixed the library usage sample in the readme because it did not match the notation of the latest version.
Please check this page for any minor issues.