### PR TITLE
Add unit tests for `buildCommandArgs` and related fixes and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ _gitignore/
 # build artifacts
 **/xk6
 **/xk6.exe
+# but not the cmd/xk6 directory
+!**/xk6/
 # generated k6 binaries
 k6
 

--- a/builder.go
+++ b/builder.go
@@ -276,12 +276,9 @@ func (b Builder) osEnvOrDefaultValue(name, defaultValue string) string {
 // buildCommandArgs parses the build flags passed by environment variable XK6_BUILD_FLAGS
 // or the default values when no value for it is given
 // so we may pass args separately to newCommand()
-func buildCommandArgs(buildFlags, absOutputFile string) (buildFlagsSlice []string) {
-	buildFlagsSlice = make([]string, 0, 10)
-
-	buildFlagsSlice = append(buildFlagsSlice, "build")
-	buildFlagsSlice = append(buildFlagsSlice, "-o")
-	buildFlagsSlice = append(buildFlagsSlice, absOutputFile)
+func buildCommandArgs(buildFlags, absOutputFile string) []string {
+	buildFlagsSlice := make([]string, 0, 10)
+	buildFlagsSlice = append(buildFlagsSlice, "build", "-o", absOutputFile)
 
 	tmp := []string{}
 	sb := &strings.Builder{}
@@ -301,9 +298,7 @@ func buildCommandArgs(buildFlags, absOutputFile string) (buildFlagsSlice []strin
 	}
 
 	buildFlagsSlice = append(buildFlagsSlice, tmp...)
-
 	buildFlagsSlice = append(buildFlagsSlice, "-trimpath")
 
-	return
-
+	return buildFlagsSlice
 }

--- a/builder.go
+++ b/builder.go
@@ -89,7 +89,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	raceArg := "-race"
 
 	// trim debug symbols by default
-	buildFlags := b.osEnvOrDefaultValue("XK6_BUILD_FLAGS", "-ldflags=-w -s")
+	buildFlags := b.osEnvOrDefaultValue("XK6_BUILD_FLAGS", "-ldflags='-w -s'")
 
 	buildFlagsSlice := buildCommandArgs(buildFlags, absOutputFile)
 

--- a/builder.go
+++ b/builder.go
@@ -91,7 +91,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	// trim debug symbols by default
 	buildFlags := b.osEnvOrDefaultValue("XK6_BUILD_FLAGS", "-ldflags=-w -s")
 
-	buildFlagsSlice := buildComandArgs(buildFlags, absOutputFile)
+	buildFlagsSlice := buildCommandArgs(buildFlags, absOutputFile)
 
 	if (b.RaceDetector || strings.Contains(buildFlags, raceArg)) && !b.Compile.Cgo {
 		log.Println("[WARNING] Enabling cgo because it is required by the race detector")
@@ -273,11 +273,10 @@ func (b Builder) osEnvOrDefaultValue(name, defaultValue string) string {
 	return s
 }
 
-// buildComandArgs parses the build flags passed by environment variable XK6_BUILD_FLAGS
+// buildCommandArgs parses the build flags passed by environment variable XK6_BUILD_FLAGS
 // or the default values when no value for it is given
 // so we may pass args separately to newCommand()
-func buildComandArgs(buildFlags, absOutputFile string) (buildFlagsSlice []string) {
-
+func buildCommandArgs(buildFlags, absOutputFile string) (buildFlagsSlice []string) {
 	buildFlagsSlice = make([]string, 0, 10)
 
 	buildFlagsSlice = append(buildFlagsSlice, "build")

--- a/builder_test.go
+++ b/builder_test.go
@@ -15,12 +15,12 @@
 package xk6
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
 
 func TestReplacementPath_Param(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		r    ReplacementPath
@@ -49,7 +49,7 @@ func TestReplacementPath_Param(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fmt.Println(tt.r.Param())
+			t.Parallel()
 			if got := tt.r.Param(); got != tt.want {
 				t.Errorf("ReplacementPath.Param() = %v, want %v", got, tt.want)
 			}
@@ -58,6 +58,7 @@ func TestReplacementPath_Param(t *testing.T) {
 }
 
 func TestNewReplace(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		old string
 		new string
@@ -80,6 +81,7 @@ func TestNewReplace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := NewReplace(tt.args.old, tt.args.new); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewReplace() = %v, want %v", got, tt.want)
 			}

--- a/builder_test.go
+++ b/builder_test.go
@@ -48,6 +48,7 @@ func TestReplacementPath_Param(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := tt.r.Param(); got != tt.want {
@@ -80,6 +81,7 @@ func TestNewReplace(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := NewReplace(tt.args.old, tt.args.new); !reflect.DeepEqual(got, tt.want) {

--- a/builder_test.go
+++ b/builder_test.go
@@ -90,3 +90,52 @@ func TestNewReplace(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildCommandArgs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		buildFlags string
+		want       []string
+	}{
+		{
+			buildFlags: "",
+			want: []string{
+				"build", "-o", "binfile", "-trimpath",
+			},
+		},
+		{
+			buildFlags: "-ldflags='-w -s'",
+			want: []string{
+				"build", "-o", "binfile", "-ldflags=-w -s", "-trimpath",
+			},
+		},
+		{
+			buildFlags: "-race -buildvcs=false",
+			want: []string{
+				"build", "-o", "binfile", "-race", "-buildvcs=false", "-trimpath",
+			},
+		},
+		{
+			buildFlags: `-buildvcs=false -ldflags="-s -w" -race`,
+			want: []string{
+				"build", "-o", "binfile", "-buildvcs=false", "-ldflags=-s -w", "-race", "-trimpath",
+			},
+		},
+		{
+			buildFlags: `-ldflags="-s -w" -race -buildvcs=false`,
+			want: []string{
+				"build", "-o", "binfile", "-ldflags=-s -w", "-race", "-buildvcs=false", "-trimpath",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.buildFlags, func(t *testing.T) {
+			t.Parallel()
+			if got := buildCommandArgs(tt.buildFlags, "binfile"); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildCommandArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/xk6/main_test.go
+++ b/cmd/xk6/main_test.go
@@ -126,6 +126,7 @@ func TestNormalizeImportPath(t *testing.T) {
 		tests = append(tests, windowsTests...)
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := normalizeImportPath(tt.args.currentModule, tt.args.cwd, tt.args.moduleDir); got != tt.want {

--- a/cmd/xk6/main_test.go
+++ b/cmd/xk6/main_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestSplitWith(t *testing.T) {
+	t.Parallel()
 	for i, tc := range []struct {
 		input         string
 		expectModule  string
@@ -83,6 +84,7 @@ func TestSplitWith(t *testing.T) {
 }
 
 func TestNormalizeImportPath(t *testing.T) {
+	t.Parallel()
 	type (
 		args struct {
 			currentModule string
@@ -125,6 +127,7 @@ func TestNormalizeImportPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := normalizeImportPath(tt.args.currentModule, tt.args.cwd, tt.args.moduleDir); got != tt.want {
 				t.Errorf("normalizeImportPath() = %v, want %v", got, tt.want)
 			}
@@ -134,6 +137,7 @@ func TestNormalizeImportPath(t *testing.T) {
 
 func TestExpandPath(t *testing.T) {
 	t.Run(". expands to current directory", func(t *testing.T) {
+		t.Parallel()
 		got, err := expandPath(".")
 		if got == "." {
 			t.Errorf("did not expand path")
@@ -143,6 +147,7 @@ func TestExpandPath(t *testing.T) {
 		}
 	})
 	t.Run("~ expands to user's home directory", func(t *testing.T) {
+		t.Parallel()
 		got, err := expandPath("~")
 		if got == "~" {
 			t.Errorf("did not expand path")


### PR DESCRIPTION
This addresses some of the pending issues from #51.