### PR TITLE
Maintenance/GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,12 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Print Go version and environment
       id: vars
@@ -60,7 +60,7 @@ jobs:
         echo "::set-output name=go_cache::$(go env GOCACHE)"
 
     - name: Cache the build cache
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ${{ steps.vars.outputs.go_cache }}
         key: ${{ runner.os }}-go-ci-${{ hashFiles('**/go.sum') }}
@@ -79,7 +79,7 @@ jobs:
         go build -trimpath -ldflags="-w -s" -v
 
     - name: Publish Build Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: xk6_${{ runner.os }}_${{ steps.vars.outputs.short_sha }}
         path: ${{ matrix.XK6_BIN_PATH }}
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: goreleaser/goreleaser-action@v1
         with:
           version: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,19 +88,27 @@ jobs:
       run: |
         go test -v -coverprofile="cover-profile.out" -short -race ./...
 
-  # From https://github.com/reviewdog/action-golangci-lint
   golangci-lint:
     name: runner / golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Run golangci-lint
-        uses: reviewdog/action-golangci-lint@v1
-        # uses: docker://reviewdog/action-golangci-lint:v1 # pre-build docker image
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
-          github_token: ${{ secrets.github_token }}
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+          check-latest: true
+      - name: Retrieve golangci-lint version
+        run: |
+          echo "Version=$(head -n 1 "${GITHUB_WORKSPACE}/.golangci.yml" | tr -d '# ')" >> $GITHUB_OUTPUT
+        id: version
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: ${{ steps.version.outputs.Version }}          
 
   goreleaser-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - uses: goreleaser/goreleaser-action@v1
+      - uses: goreleaser/goreleaser-action@v4
         with:
-          version: latest
+          version: v1.13.1
           args: check
         env:
           TAG: ${{ steps.vars.outputs.short_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: ${{ steps.version.outputs.Version }}          
+          version: ${{ steps.version.outputs.Version }}
 
   goreleaser-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
 
     - name: Print Go version and environment
       id: vars
+      shell: bash
       run: |
         printf "Using go at: $(which go)\n"
         printf "Go version: $(go version)\n"
@@ -56,8 +57,8 @@ jobs:
         printf "\n\nSystem environment:\n\n"
         env
         # Calculate the short SHA1 hash of the git commit
-        echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
-        echo "::set-output name=go_cache::$(go env GOCACHE)"
+        echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        echo "go_cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
 
     - name: Cache the build cache
       uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
 
     - name: Print Go version and environment
       id: vars
+      shell: bash
       run: |
         printf "Using go at: $(which go)\n"
         printf "Go version: $(go version)\n"
@@ -36,8 +37,8 @@ jobs:
         go env
         printf "\n\nSystem environment:\n\n"
         env
-        echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
-        echo "::set-output name=go_cache::$(go env GOCACHE)"
+        echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        echo "go_cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
 
     - name: Cache the build cache
       uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # So GoReleaser can generate the changelog properly
     - name: Unshallowify the repo clone
@@ -40,7 +40,7 @@ jobs:
         echo "::set-output name=go_cache::$(go env GOCACHE)"
 
     - name: Cache the build cache
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ${{ steps.vars.outputs.go_cache }}
         key: ${{ runner.os }}-go-release-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
 
     # GoReleaser will take care of publishing those artifacts into the release
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v1
+      uses: goreleaser/goreleaser-action@v4
       with:
-        version: latest
+        version: v1.13.1
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+# v1.50.1
+# Please don't remove the first line. It uses in CI to determine the golangci version
 linters-settings:
   errcheck:
     ignore: fmt:.*,io/ioutil:^Read.*

--- a/builder.go
+++ b/builder.go
@@ -17,7 +17,6 @@ package xk6
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -109,7 +108,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	cmd := buildEnv.newCommand("go",
 		buildFlagsSlice...,
 	)
-	//dont add raceArg again if it already in place
+	// dont add raceArg again if it already in place
 	if b.RaceDetector && !strings.Contains(buildFlags, raceArg) {
 		cmd.Args = append(cmd.Args, raceArg)
 	}
@@ -213,7 +212,7 @@ func newTempFolder() (string, error) {
 		}
 	}
 	ts := time.Now().Format(yearMonthDayHourMin)
-	return ioutil.TempDir(parentDir, fmt.Sprintf("buildenv_%s.", ts))
+	return os.MkdirTemp(parentDir, fmt.Sprintf("buildenv_%s.", ts))
 }
 
 // versionedModulePath helps enforce Go Module's Semantic Import Versioning (SIV) by

--- a/environment.go
+++ b/environment.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -160,7 +159,7 @@ nextExt:
 	// we do this last so we get the needed versions from all the replacements and extensions instead of k6 if possible
 	mainPath := filepath.Join(tempFolder, "main.go")
 	log.Printf("[INFO] Writing main module: %s", mainPath)
-	err = ioutil.WriteFile(mainPath, buf.Bytes(), 0o600)
+	err = os.WriteFile(mainPath, buf.Bytes(), 0o600)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +209,7 @@ func (env environment) writeExtensionImportFile(packagePath string) error {
 import _ %q
 `, packagePath)
 	filePath := filepath.Join(env.tempFolder, strings.ReplaceAll(packagePath, "/", "_")+".go")
-	return ioutil.WriteFile(filePath, []byte(fileContents), 0o600)
+	return os.WriteFile(filePath, []byte(fileContents), 0o600)
 }
 
 func (env environment) newCommand(command string, args ...string) *exec.Cmd {
@@ -260,7 +259,7 @@ func (env environment) runCommand(ctx context.Context, cmd *exec.Cmd, timeout ti
 		// to the child process, so wait for it to die
 		select {
 		case <-time.After(15 * time.Second):
-			cmd.Process.Kill()
+			_ = cmd.Process.Kill()
 		case <-cmdErrChan:
 		}
 		return ctx.Err()


### PR DESCRIPTION
# What?

These changes are:
* Cleaning of using deprecated things in CI (`set-output` and `Node 12.X`) in Golang (`ioutil`).
* Using an official `golangci-lint` action and bumping the `goreleaser` at the latest working version (the actual update of it I prefer to keep out of this in #59)

# Why?

Resolves #54 