### PR TITLE
Remove experimental warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ This command line tool and associated Go package makes it easy to make custom bu
 
 It is used heavily by k6 extension developers as well as anyone who wishes to make custom `k6` binaries (with or without extensions).
 
-⚠️ Still in development.
-
-Stay updated, be aware of changes, and please submit feedback! Thanks!
 
 ## Requirements
 


### PR DESCRIPTION
This project has been used extensively for the past 2 years, and while there are still some rough edges, it doesn't require much maintenance, so we can remove this warning.