### PR TITLE
Add Dockerfile and publish image to container registries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,15 @@ name: Release
 
 on:
   push:
+    branches:
+      - master
     tags:
       - 'v*.*.*'
 
 jobs:
   release:
-    name: Release
+    name: Release GitHub
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     strategy:
       matrix:
         os: [ ubuntu-latest ]
@@ -56,3 +59,79 @@ jobs:
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Build and publish Docker image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_REPOSITORY: ${{ github.repository }}
+      VERSION: ${{ github.ref_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Build image
+        run: docker build -t "$IMAGE_REPOSITORY" .
+      - name: Build k6 binary
+        run: |
+            docker run --rm -u "$(id -u):$(id -g)" -v "$PWD:/xk6" \
+              "$IMAGE_REPOSITORY" build master \
+              --with github.com/mostafa/xk6-kafka \
+              --with github.com/grafana/xk6-output-influxdb
+      - name: Check k6 binary
+        run: |
+            ./k6 version
+            ./k6 version | grep -qz 'xk6-output-influxdb.*xk6-kafka'
+
+      - name: Log into ghcr.io
+        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Publish master image to ghcr.io
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          echo "Publish as ghcr.io/${IMAGE_REPOSITORY}:master"
+          docker tag "$IMAGE_REPOSITORY" "ghcr.io/${IMAGE_REPOSITORY}:master"
+          docker push "ghcr.io/${IMAGE_REPOSITORY}:master"
+
+      - name: Publish tagged version image to ghcr.io
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          VERSION="${VERSION#v}"
+          echo "Publish as ghcr.io/${IMAGE_REPOSITORY}:${VERSION}"
+          docker tag "$IMAGE_REPOSITORY" "ghcr.io/${IMAGE_REPOSITORY}:${VERSION}"
+          docker push "ghcr.io/${IMAGE_REPOSITORY}:${VERSION}"
+          # We also want to tag the latest stable version as latest
+          if [[ ! "$VERSION" =~ (RC|rc) ]]; then
+            echo "Publish as ghcr.io/${IMAGE_REPOSITORY}:latest"
+            docker tag "$IMAGE_REPOSITORY" "ghcr.io/${IMAGE_REPOSITORY}:latest"
+            docker push "ghcr.io/${IMAGE_REPOSITORY}:latest"
+          fi
+
+      - name: Log into Docker Hub
+        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          echo "${{ secrets.DOCKER_PASS }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
+
+      - name: Publish master image to Docker Hub
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          echo "Publish as ${IMAGE_REPOSITORY}:master"
+          docker tag "$IMAGE_REPOSITORY" "${IMAGE_REPOSITORY}:master"
+          docker push "${IMAGE_REPOSITORY}:master"
+
+      - name: Publish tagged version image to Docker Hub
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          VERSION="${VERSION#v}"
+          echo "Publish as ${IMAGE_REPOSITORY}:${VERSION}"
+          docker tag "$IMAGE_REPOSITORY" "${IMAGE_REPOSITORY}:${VERSION}"
+          docker push "${IMAGE_REPOSITORY}:${VERSION}"
+          # We also want to tag the latest stable version as latest
+          if [[ ! "$VERSION" =~ (RC|rc) ]]; then
+            echo "Publish as ${IMAGE_REPOSITORY}:latest"
+            docker tag "$IMAGE_REPOSITORY" "${IMAGE_REPOSITORY}:latest"
+            docker push "${IMAGE_REPOSITORY}:latest"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+ARG GO_VERSION=1.20.1
+ARG VARIANT=bullseye
+FROM golang:${GO_VERSION}-${VARIANT} as builder
+
+WORKDIR /build
+
+COPY . .
+
+ARG GOFLAGS="-ldflags=-w -ldflags=-s"
+RUN CGO_ENABLED=0 go build -o xk6 -trimpath ./cmd/xk6/main.go
+
+
+FROM golang:${GO_VERSION}-${VARIANT}
+
+RUN addgroup --gid 1000 xk6 && \
+    adduser --uid 1000 --ingroup xk6 --home /home/xk6 --shell /bin/sh --disabled-password --gecos "" xk6
+
+ARG FIXUID_VERSION=0.5.1
+RUN USER=xk6 && \
+    GROUP=xk6 && \
+    curl -fSsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+
+COPY --from=builder /build/xk6 /usr/local/bin/
+
+COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+
+WORKDIR /xk6
+RUN chown xk6:xk6 /xk6
+USER xk6
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -9,11 +9,72 @@ It is used heavily by k6 extension developers as well as anyone who wishes to ma
 
 Stay updated, be aware of changes, and please submit feedback! Thanks!
 
-## Requirements
+## Docker
+
+The easiest way to use xk6 is via our [Docker image](https://hub.docker.com/r/grafana/xk6/). This avoids having to setup a local Go environment, and install xk6 manually.
+
+For example, to build a k6 v0.43.0 binary on Linux with the [xk6-kafka](https://github.com/mostafa/xk6-kafka) and [xk6-output-influxdb](https://github.com/grafana/xk6-output-influxdb) extensions, you would run:
+
+```bash
+docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6 build v0.43.1 \
+  --with github.com/mostafa/xk6-kafka@v0.17.0 \
+  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+```
+
+This would create a `k6` binary in the current working directory.
+
+Note the use of the `-u` (user) option to specify the user and group IDs of the account on the host machine. This is important for the `k6` file to have the same file permissions as the host user.
+
+The `-v` (volume) option is also required to mount the current working directory inside the container, so that the `k6` binary can be written to it.
+
+Note that if you're using SELinux, you might need to add `:z` to the `--volume` option to avoid permission errors. E.g. `-v "${PWD}:/xk6:z"`.
+
+If you prefer to setup Go and use xk6 without Docker, see the "Local Installation" section below.
+
+
+### macOS
+
+On macOS you will need to set the `GOOS=darwin` environment variable to build a macOS binary.
+
+You can do this with the `--env` or `-e` argument to `docker run`:
+```bash
+docker run --rm -it -e GOOS=darwin -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" \
+  grafana/xk6 build v0.43.1 \
+  --with github.com/mostafa/xk6-kafka@v0.17.0 \
+  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+```
+
+
+### Windows
+
+On Windows you can either build a native Windows binary, or, if you're using WSL2, a Linux binary you can use in WSL2.
+
+For the native Windows binary if you're using PowerShell:
+```powershell
+docker run --rm -it -e GOOS=windows -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" `
+  grafana/xk6 build v0.43.1 --output k6.exe `
+  --with github.com/mostafa/xk6-kafka@v0.17.0 `
+  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+```
+
+For the native Windows binary if you're using cmd.exe:
+```batch
+docker run --rm -it -e GOOS=windows -v "%cd%:/xk6" ^
+  grafana/xk6 build v0.43.1 --output k6.exe ^
+  --with github.com/mostafa/xk6-kafka@v0.17.0 ^
+  --with github.com/grafana/xk6-output-influxdb@v0.3.0
+```
+
+For the Linux binary on WSL2, you can use the same command as for Linux.
+
+
+## Local Installation
+
+### Requirements
 
 - [Go installed](https://golang.org/doc/install). At least version 1.17 is needed.
 
-## Install
+### Install xk6
 
 You can [download binaries](https://github.com/grafana/xk6/releases) that are already compiled for your platform, or build `xk6` from source:
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+eval "$(fixuid)"
+
+exec /usr/local/bin/xk6 "$@"


### PR DESCRIPTION
This allows using xk6 via Docker, without having to setup a local Go environment or install xk6.

Unfortunately, file permissions with mounted volumes are [still an issue](https://github.com/moby/moby/issues/7198), without a simple, native fix. [fixuid](https://github.com/boxboat/fixuid) seems to be the modern solution to this, and works well from my tests.

The `grafana/xk6` image isn't published yet, which will be done after this is merged, and we make a new release. I've tested publishing to GHCR in my fork, which [worked fine](https://github.com/imiric/xk6/pkgs/container/xk6).

In the meantime, you can build it with e.g. `docker build -t test/xk6 .`.

Closes #8