### PR TITLE
CI: Add build for linux/arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
   docker:
     name: Build and publish Docker image
     runs-on: ubuntu-latest
+    needs: [binary]
     env:
       IMAGE_REPOSITORY: ${{ github.repository }}
       VERSION: ${{ github.ref_name }}
@@ -40,7 +41,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up QEMU
+      - name: Set up QEMU to build the arm64 binary
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,19 +8,16 @@ on:
       - 'v*.*.*'
 
 jobs:
-  docker:
-    name: Build and publish Docker image
+  binary:
+    name: Build and test xk6 binary
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ linux/amd64, linux/arm64 ]
     env:
       IMAGE_REPOSITORY: ${{ github.repository }}
       VERSION: ${{ github.ref_name }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Build image
-        run: docker build -t "$IMAGE_REPOSITORY" .
       - name: Build k6 binary
         run: |
             docker run --rm -u "$(id -u):$(id -g)" -v "$PWD:/xk6" \
@@ -32,54 +29,55 @@ jobs:
             ./k6 version
             ./k6 version | grep -qz 'xk6-output-influxdb.*xk6-kafka'
 
+  docker:
+    name: Build and publish Docker image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_REPOSITORY: ${{ github.repository }}
+      VERSION: ${{ github.ref_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Log into ghcr.io
-        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Publish master image to ghcr.io
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: |
-          echo "Publish as ghcr.io/${IMAGE_REPOSITORY}:master"
-          docker tag "$IMAGE_REPOSITORY" "ghcr.io/${IMAGE_REPOSITORY}:master"
-          docker push "ghcr.io/${IMAGE_REPOSITORY}:master"
-
-      - name: Publish tagged version image to ghcr.io
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: |
-          VERSION="${VERSION#v}"
-          echo "Publish as ghcr.io/${IMAGE_REPOSITORY}:${VERSION}"
-          docker tag "$IMAGE_REPOSITORY" "ghcr.io/${IMAGE_REPOSITORY}:${VERSION}"
-          docker push "ghcr.io/${IMAGE_REPOSITORY}:${VERSION}"
-          # We also want to tag the latest stable version as latest
-          if [[ ! "$VERSION" =~ (RC|rc) ]]; then
-            echo "Publish as ghcr.io/${IMAGE_REPOSITORY}:latest"
-            docker tag "$IMAGE_REPOSITORY" "ghcr.io/${IMAGE_REPOSITORY}:latest"
-            docker push "ghcr.io/${IMAGE_REPOSITORY}:latest"
-          fi
-
+        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log into Docker Hub
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
-        run: |
-          echo "${{ secrets.DOCKER_PASS }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
-
-      - name: Publish master image to Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: |
-          echo "Publish as ${IMAGE_REPOSITORY}:master"
-          docker tag "$IMAGE_REPOSITORY" "${IMAGE_REPOSITORY}:master"
-          docker push "${IMAGE_REPOSITORY}:master"
-
-      - name: Publish tagged version image to Docker Hub
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: |
-          VERSION="${VERSION#v}"
-          echo "Publish as ${IMAGE_REPOSITORY}:${VERSION}"
-          docker tag "$IMAGE_REPOSITORY" "${IMAGE_REPOSITORY}:${VERSION}"
-          docker push "${IMAGE_REPOSITORY}:${VERSION}"
-          # We also want to tag the latest stable version as latest
-          if [[ ! "$VERSION" =~ (RC|rc) ]]; then
-            echo "Publish as ${IMAGE_REPOSITORY}:latest"
-            docker tag "$IMAGE_REPOSITORY" "${IMAGE_REPOSITORY}:latest"
-            docker push "${IMAGE_REPOSITORY}:latest"
-          fi
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+      - name: Set up tags
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.IMAGE_REPOSITORY }}
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}
+          flavor: |
+            # don't automatically tag master as latest
+            latest=false
+          tags: |
+            # tag: master
+            type=raw,value=master,enable=${{ github.ref == 'refs/heads/master' }}
+            # tag: major.minor.patch on tag events
+            type=semver,pattern={{version}}
+            # tag latest on stable tag pushes
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc') && !contains(github.ref, 'RC') }}
+      - name: Build image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN addgroup --gid 1000 xk6 && \
 ARG FIXUID_VERSION=0.5.1
 RUN USER=xk6 && \
     GROUP=xk6 && \
-    curl -fSsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    DPKG_ARCH="$(dpkg --print-architecture | awk -F- '{ print $NF }')" && \
+    curl -fSsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-${DPKG_ARCH}.tar.gz | tar -C /usr/local/bin -xzf - && \
     chown root:root /usr/local/bin/fixuid && \
     chmod 4755 /usr/local/bin/fixuid && \
     mkdir -p /etc/fixuid && \


### PR DESCRIPTION
This builds and pushes a multi-arch Docker manifest for amd64 and arm64.

We use Docker's provided action to do this using qemu emulation, and switch to using this to push the images for us.

Split the build/test of the `xk6` binary out to a separate job too, so that can also be run on arm64.