### PR TITLE
Update build flags to make `-trimpath` go flag configurable

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -88,7 +88,7 @@ func (b Builder) Build(ctx context.Context, outputFile string) error {
 	raceArg := "-race"
 
 	// trim debug symbols by default
-	buildFlags := b.osEnvOrDefaultValue("XK6_BUILD_FLAGS", "-ldflags='-w -s'")
+	buildFlags := b.osEnvOrDefaultValue("XK6_BUILD_FLAGS", "-ldflags='-w -s' -trimpath")
 
 	buildFlagsSlice := buildCommandArgs(buildFlags, absOutputFile)
 
@@ -297,7 +297,6 @@ func buildCommandArgs(buildFlags, absOutputFile string) []string {
 	}
 
 	buildFlagsSlice = append(buildFlagsSlice, tmp...)
-	buildFlagsSlice = append(buildFlagsSlice, "-trimpath")
 
 	return buildFlagsSlice
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -100,31 +100,31 @@ func TestBuildCommandArgs(t *testing.T) {
 		{
 			buildFlags: "",
 			want: []string{
-				"build", "-o", "binfile", "-trimpath",
+				"build", "-o", "binfile",
 			},
 		},
 		{
 			buildFlags: "-ldflags='-w -s'",
 			want: []string{
-				"build", "-o", "binfile", "-ldflags=-w -s", "-trimpath",
+				"build", "-o", "binfile", "-ldflags=-w -s",
 			},
 		},
 		{
 			buildFlags: "-race -buildvcs=false",
 			want: []string{
-				"build", "-o", "binfile", "-race", "-buildvcs=false", "-trimpath",
+				"build", "-o", "binfile", "-race", "-buildvcs=false",
 			},
 		},
 		{
 			buildFlags: `-buildvcs=false -ldflags="-s -w" -race`,
 			want: []string{
-				"build", "-o", "binfile", "-buildvcs=false", "-ldflags=-s -w", "-race", "-trimpath",
+				"build", "-o", "binfile", "-buildvcs=false", "-ldflags=-s -w", "-race",
 			},
 		},
 		{
 			buildFlags: `-ldflags="-s -w" -race -buildvcs=false`,
 			want: []string{
-				"build", "-o", "binfile", "-ldflags=-s -w", "-race", "-buildvcs=false", "-trimpath",
+				"build", "-o", "binfile", "-ldflags=-s -w", "-race", "-buildvcs=false",
 			},
 		},
 	}


### PR DESCRIPTION
## Context and Problem

While working on integrating the Streams API into k6 using xk6 extensions, I encountered a significant challenge in debugging with VSCode. Specifically, the debugger could not associate breakpoints with the correct file paths. This issue stems from the `-trimpath` argument in our build process, which removes file system paths from the executable, thus hindering the debugger's ability to function correctly.

## Solution

This PR modifies the build process for xk6 extensions. By adjusting where and how the `-trimpath` flag is applied, we allow extension developers to override this setting using the `XK6_BUILD_FLAGS` environment variable. This change offers more flexibility in preserving debug symbols and optimizing the debugging experience in VSCode.

### For the history books: Debugging in VSCode using this fix

For those looking to debug xk6 extensions in VSCode, here's a guide based on my setup:

#### Build Task Configuration

Create a VSCode task to build the xk6 binary with the necessary flags for debugging. This task utilizes the changes introduced in this PR. Here's the configuration in `tasks.json`:

```json
{
    "version": "2.0.0",
    "tasks": [
        {
            "type": "shell",
            "command": "xk6",
            "args": [
                "build",
                "--with",
                "github.com/grafana/xk6-streams=.",  // Replace with your extension
                "--output",
                "${workspaceFolder}/k6"
            ],
            "group": "build",
            "label": "xk6: build",
            "options": {
                "env": {
                    "XK6_BUILD_FLAGS": "-gcflags 'all=-N -l'"
                }
            }
        }
    ]
}
```

Define a launch.json file in VSCode to run the above build task before starting the debugger. Here's the configuration:

```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "xk6",
            "type": "go",
            "request": "launch",
            "mode": "exec",
            "preLaunchTask": "xk6: build",
            "cwd": "${workspaceFolder}",
            "program": "${workspaceFolder}/k6",
            "args": ["run", "${workspaceFolder}/examples/readablestream-numbers.js"]
        }
    ]
}
```

## References

ref #51 
ref #43 