### PR TITLE
install git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN CGO_ENABLED=0 GOBIN=/build go install github.com/boxboat/fixuid@${FIXUID_VER
 
 FROM golang:${GO_VERSION}-${VARIANT}
 
+RUN apk update && apk add git
+
 COPY --from=builder /build/fixuid /usr/local/bin/
 
 RUN chown root:root /usr/local/bin/fixuid && \


### PR DESCRIPTION
In some circumstances `go mod` command needs git binary to download packages (e.g. when using private packages not provided by `proxy.golang.org`), but the Alpine-based golang image doesn't have git installed by default.
