### PR TITLE
create binary release artifacts using goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
           fi
 
   binary:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     name: Build and attach binary artifacts
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,3 +79,24 @@ jobs:
               -t "ghcr.io/${IMAGE_REPOSITORY}:latest" .
           fi
 
+  binary:
+    name: Build and attach binary artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "2.4.7"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,27 @@
+project_name: xk6
+version: 2
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos: ["darwin", "linux", "windows"]
+    goarch: ["amd64", "arm64"]
+    ldflags: ["-s -w"]
+    dir: cmd/xk6
+    binary: xk6
+
+source:
+  enabled: true
+  name_template: "{{ .ProjectName }}_{{ .Version }}_source"
+
+archives:
+  - id: bundle
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next+{{.ShortCommit}}{{if .IsGitDirty}}.dirty{{else}}{{end}}"

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ clean:
 build:
 	go build -work ./cmd/xk6
 
+## snapshot: Create snapshot build using goreleaser.
+snapshot:
+	goreleaser build --clean --snapshot --single-target -o xk6
+
 ## format: Applies Go formatting to code.
 format:
 	go fmt ./...


### PR DESCRIPTION
Create and publish binary release artifacts for the most common platforms using [goreleaser](https://goreleaser.com/).

[goreleaser](https://goreleaser.com/) is a common and good tool for creating release artifacts: binaries for different platforms, docker images, packages for different package managers, etc.

Binary artifacts will be created for the following platforms:
```yaml
goos: ["darwin", "linux", "windows"]
goarch: ["amd64", "arm64"]
```
