### PR TITLE
Use GoReleaser to release docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,72 +16,72 @@ jobs:
       # Default is true, cancels jobs for other platforms in the matrix if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go-version: [ 1.22.x ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [1.23.x]
 
         # Set some variables per OS, usable via ${{ matrix.VAR }}
         # XK6_BIN_PATH: the path to the compiled k6 binary, for artifact publishing
         # SUCCESS: the typical value for $? per OS (Windows/pwsh returns 'True')
         include:
-        - os: ubuntu-latest
-          XK6_BIN_PATH: ./cmd/xk6/xk6
-          SUCCESS: 0
+          - os: ubuntu-latest
+            XK6_BIN_PATH: ./cmd/xk6/xk6
+            SUCCESS: 0
 
-        - os: macos-latest
-          XK6_BIN_PATH: ./cmd/xk6/xk6
-          SUCCESS: 0
+          - os: macos-latest
+            XK6_BIN_PATH: ./cmd/xk6/xk6
+            SUCCESS: 0
 
-        - os: windows-latest
-          XK6_BIN_PATH: ./cmd/xk6/xk6.exe
-          SUCCESS: 'True'
+          - os: windows-latest
+            XK6_BIN_PATH: ./cmd/xk6/xk6.exe
+            SUCCESS: "True"
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
 
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Print Go version and environment
-      id: vars
-      shell: bash
-      run: |
-        printf "Using go at: $(which go)\n"
-        printf "Go version: $(go version)\n"
-        printf "\n\nGo environment:\n\n"
-        go env
-        printf "\n\nSystem environment:\n\n"
-        env
-        # Calculate the short SHA1 hash of the git commit
-        echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-        echo "go_cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+      - name: Print Go version and environment
+        id: vars
+        shell: bash
+        run: |
+          printf "Using go at: $(which go)\n"
+          printf "Go version: $(go version)\n"
+          printf "\n\nGo environment:\n\n"
+          go env
+          printf "\n\nSystem environment:\n\n"
+          env
+          # Calculate the short SHA1 hash of the git commit
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "go_cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
 
-    - name: Cache the build cache
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.vars.outputs.go_cache }}
-        key: ${{ runner.os }}-go-ci-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-ci
+      - name: Cache the build cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.vars.outputs.go_cache }}
+          key: ${{ runner.os }}-go-ci-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-ci
 
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
 
-    - name: Build xk6
-      working-directory: ./cmd/xk6
-      env:
-        CGO_ENABLED: 0
-      run: |
-        go build -trimpath -ldflags="-w -s" -v
+      - name: Build xk6
+        working-directory: ./cmd/xk6
+        env:
+          CGO_ENABLED: 0
+        run: |
+          go build -trimpath -ldflags="-w -s" -v
 
-    - name: Run tests
-      run: |
-        go test -v -coverprofile="cover-profile.out" -short -race ./...
+      - name: Run tests
+        run: |
+          go test -v -coverprofile="cover-profile.out" -short -race ./...
 
   golangci-lint:
     name: runner / golangci-lint
@@ -94,7 +94,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
           check-latest: true
       - name: Retrieve golangci-lint version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23.x
           check-latest: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Dry Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: "2.6.1"
+          version: "~> v2"
           args: release --clean --snapshot
 
       - name: Test Docker Image
@@ -56,7 +56,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: "2.6.1"
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,85 +2,12 @@ name: Release
 
 on:
   push:
-    branches:
-      - master
-    tags:
-      - 'v*.*.*'
+    branches: ["master"]
+    tags: ["v*.*.*"]
 
 jobs:
-  docker:
-    name: Build and publish Docker image
-    runs-on: ubuntu-latest
-    env:
-      IMAGE_REPOSITORY: ${{ github.repository }}
-      VERSION: ${{ github.ref_name }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Build image
-        run: |
-          docker buildx create \
-            --name multibuilder \
-            --platform linux/amd64,linux/arm64 \
-            --bootstrap --use
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
-            -t "$IMAGE_REPOSITORY" .
-
-      - name: Build k6 binary
-        run: |
-            docker run --rm -u "$(id -u):$(id -g)" -v "$PWD:/xk6" \
-              "$IMAGE_REPOSITORY" build latest \
-              --with github.com/grafana/xk6-sql \
-              --with github.com/grafana/xk6-output-influxdb
-      - name: Check k6 binary
-        run: |
-            ./k6 version
-            ./k6 version | grep -qz 'xk6-output-influxdb.*xk6-sql'
-
-      - name: Log into ghcr.io
-        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Log into Docker Hub
-        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
-        run: |
-          echo "${{ secrets.DOCKER_PASS }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
-
-      - name: Publish master image
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: |
-          echo "Publish as master"
-          docker buildx build --push \
-            --platform linux/amd64,linux/arm64 \
-            -t ${IMAGE_REPOSITORY}:master \
-            -t "ghcr.io/${IMAGE_REPOSITORY}:master" .
-
-      - name: Publish tagged version
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: |
-          VERSION="${VERSION#v}"
-          echo "Publish as ${VERSION}"
-          docker buildx build --push \
-              --platform linux/amd64,linux/arm64 \
-              -t ${IMAGE_REPOSITORY}:${VERSION} \
-              -t "ghcr.io/${IMAGE_REPOSITORY}:${VERSION}" .
-          # We also want to tag the latest stable version as latest
-          if [[ ! "$VERSION" =~ (RC|rc) ]]; then
-            echo "Publish as latest"
-            docker buildx build --push \
-              --platform linux/amd64,linux/arm64 \
-              -t ${IMAGE_REPOSITORY}:latest \
-              -t "ghcr.io/${IMAGE_REPOSITORY}:latest" .
-          fi
-
-  binary:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    name: Build and attach binary artifacts
+  release:
+    name: Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -88,15 +15,48 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.x"
+          go-version: "1.23.x"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: "amd64,arm64"
+
+      - name: Dry Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "2.6.1"
+          args: release --clean --snapshot
+
+      - name: Test Docker Image
+        run: |
+          mkdir ${{ runner.temp }}/testrun
+          cd ${{ runner.temp }}/testrun
+          docker run --rm -u "$(id -u):$(id -g)" -v "$PWD:/xk6" ${{ github.repository }}:latest-amd64 \
+            build --with github.com/grafana/xk6-faker
+          ./k6 version | grep -q xk6-faker
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Login to GitHub Packages
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
-          version: "2.4.7"
+          version: "2.6.1"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.59.1
+# v1.63.4
 # Please don't remove the first line. It uses in CI to determine the golangci version
 linters-settings:
   errcheck:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,13 +1,31 @@
 project_name: xk6
 version: 2
+
+env:
+  - IMAGE=grafana/{{.ProjectName}}
+
+before:
+  hooks:
+    - go mod tidy
+
 builds:
-  - env:
-      - CGO_ENABLED=0
-    goos: ["darwin", "linux", "windows"]
-    goarch: ["amd64", "arm64"]
-    ldflags: ["-s -w"]
-    dir: cmd/xk6
+  - id: xk6
     binary: xk6
+    main: ./cmd/xk6
+    goos: ["linux", "windows", "darwin"]
+    goarch: ["amd64", "arm64"]
+    flags: ["-trimpath"]
+    env: ["CGO_ENABLED=0"]
+    ldflags: ["-s -w"]
+
+  - id: fixids
+    binary: fixids
+    main: ./internal/fixids
+    goos: ["linux"]
+    goarch: ["amd64", "arm64"]
+    flags: ["-trimpath"]
+    env: ["CGO_ENABLED=0"]
+    ldflags: ["-s -w"]
 
 source:
   enabled: true
@@ -15,13 +33,105 @@ source:
 
 archives:
   - id: bundle
-    format: tar.gz
+    builds: ["xk6"]
+    formats: ["tar.gz"]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next+{{.ShortCommit}}{{if .IsGitDirty}}.dirty{{else}}{{end}}"
+
+dockers:
+  - id: amd64
+    ids: ["xk6", "fixids"]
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    extra_files: ["docker-entrypoint.sh"]
+    image_templates:
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Tag }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:latest-amd64"
+
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Tag }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:latest-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.licenses=AGPL-3.0-only"
+  - id: arm64
+    ids: ["xk6", "fixids"]
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    extra_files: ["docker-entrypoint.sh"]
+    image_templates:
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Tag }}-arm64"
+      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}-arm64"
+      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "docker.io/{{ .Env.IMAGE }}:latest-arm64"
+
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Tag }}-arm64"
+      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}-arm64"
+      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "ghcr.io/{{ .Env.IMAGE }}:latest-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.licenses=AGPL-3.0-only"
+
+docker_manifests:
+  - id: tag
+    name_template: "docker.io/{{ .Env.IMAGE }}:{{ .Tag }}"
+    image_templates:
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Tag }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Tag }}-arm64"
+  - id: major
+    name_template: "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}"
+    image_templates:
+      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}-arm64"
+  - id: major-minor
+    name_template: "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-arm64"
+  - id: latest
+    name_template: "docker.io/{{ .Env.IMAGE }}:latest"
+    image_templates:
+      - "docker.io/{{ .Env.IMAGE }}:latest-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:latest-arm64"
+
+  - id: tag-ghcr
+    name_template: "ghcr.io/{{ .Env.IMAGE }}:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Tag }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Tag }}-arm64"
+  - id: major-ghcr
+    name_template: "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}"
+    image_templates:
+      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}-arm64"
+  - id: major-minor-ghcr
+    name_template: "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-arm64"
+  - id: latest-ghcr
+    name_template: "ghcr.io/{{ .Env.IMAGE }}:latest"
+    image_templates:
+      - "ghcr.io/{{ .Env.IMAGE }}:latest-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:latest-arm64"

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,16 +1,5 @@
-
 ARG GO_VERSION=1.23.7
 ARG VARIANT=alpine3.21
-FROM golang:${GO_VERSION}-${VARIANT} AS builder
-
-WORKDIR /build
-
-COPY . .
-
-ARG GOFLAGS="-ldflags=-w -ldflags=-s"
-
-RUN CGO_ENABLED=0 go build -o /xk6 -trimpath ./cmd/xk6
-RUN CGO_ENABLED=0 go build -o /fixids -trimpath ./internal/fixids
 
 FROM golang:${GO_VERSION}-${VARIANT}
 
@@ -18,8 +7,8 @@ RUN apk update && apk add git && \
     addgroup --gid 1000 xk6 && \
     adduser --uid 1000 --ingroup xk6 --disabled-password --gecos "" xk6
 
-COPY --from=builder --chown=root:root --chmod=4755 fixids /usr/local/bin/
-COPY --from=builder --chown=xk6:xk6 --chmod=755 xk6 /usr/local/bin/
+COPY --chown=root:root --chmod=4755 fixids /usr/local/bin/
+COPY --chown=xk6:xk6 --chmod=755 xk6 /usr/local/bin/
 COPY --chown=root:root --chmod=755 docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 
 WORKDIR /xk6

--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ Note that if you're using SELinux, you might need to add `:z` to the `--volume` 
 
 If you prefer to setup Go and use xk6 without Docker, see the "Local Installation" section below.
 
+Docker images can be used with major version, minor version, and specific version tags.
+
+For example, let's say `1.2.3` is the latest xk6 Docker image version.
+- the latest release of major version `1` is available using the `v1` tag:
+  ```bash
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1
+  ```
+- the latest release of minor version `1.2` is available using the `v1.2` tag:
+  ```bash
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1.2
+  ```
+- of course version `1.2.3` is still available using the `v1.2.3` tag:
+  ```bash
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1.2.3
+  ```
+- the latest release is still available using the `latest` tag:
+  ```bash
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@latest
+  ```
+
+> [!IMPORTANT]
+> In CI pipelines it is recommended to use the major version tag (or the minor version tag) instead of the latest tag. Using the `latest` tag ignores the benefits of semantic versioning and can easily break the CI pipeline. 
 
 ### macOS
 

--- a/builder.go
+++ b/builder.go
@@ -132,7 +132,7 @@ func (b Builder) Build(ctx context.Context, log *slog.Logger, outfile string) er
 	if err != nil {
 		return err
 	}
-	outFile, err := os.OpenFile(absOutputFile, os.O_WRONLY|os.O_CREATE, 0o777) //nolint:gosec
+	outFile, err := os.OpenFile(absOutputFile, os.O_WRONLY|os.O_CREATE, 0o777) // #nosec G302 G304
 	if err != nil {
 		return err
 	}

--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -90,7 +90,7 @@ func runBuild(ctx context.Context, log *slog.Logger, args []string) error {
 		}
 		fmt.Println()
 		fmt.Printf("%s version\n", output)
-		cmd := exec.Command(output, "version")
+		cmd := exec.Command(output, "version") // #nosec G204
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
@@ -176,7 +176,7 @@ func runDev(ctx context.Context, log *slog.Logger, args []string) error {
 	}
 
 	log.Info(fmt.Sprintf("Running %v\n\n", append([]string{outfile}, args...)))
-	cmd = exec.Command(outfile, args...)
+	cmd = exec.Command(outfile, args...) // #nosec G204
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 
-eval "$(fixuid)"
+eval "$(fixids -q xk6 xk6)"
 
-exec /usr/local/bin/xk6 "$@"
+exec xk6 "$@"

--- a/examples/build-with-docker.sh
+++ b/examples/build-with-docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -u "$(id -u):$(id -g)" -v "$PWD:/xk6" grafana/k6 build --with github.com/grafana/xk6-faker

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module go.k6.io/xk6
 
-go 1.22.2
+go 1.23.0
+
+toolchain go1.23.7
 
 require github.com/grafana/k6foundry v0.4.5
 

--- a/internal/fixids/README.md
+++ b/internal/fixids/README.md
@@ -1,0 +1,17 @@
+# fixids
+
+Fix user id and group id in docker containers.
+
+Original source code is from [fixuid](https://github.com/boxboat/fixuid) (v0.6.0).
+
+**Usage**
+
+```bash
+#!/bin/sh
+
+set -e
+
+eval "$(fixids -q xk6 xk6)"
+
+exec xk6 "$@"
+```

--- a/internal/fixids/fixids.go
+++ b/internal/fixids/fixids.go
@@ -1,0 +1,533 @@
+//go:build linux
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const ranFile = "/var/run/fixids.ran"
+
+var logger = log.New(os.Stderr, "", 0)
+var quietFlag = flag.Bool("q", false, "quiet mode")
+
+func main() {
+	runtime.GOMAXPROCS(1)
+	logger.SetPrefix("fixids: ")
+	flag.Parse()
+
+	argsWithoutProg := flag.Args()
+
+	if len(argsWithoutProg) < 2 {
+		logger.Fatalln("Usage: fixids user-name group-name")
+	}
+
+	// detect what user we are running as
+	runtimeUIDInt := os.Getuid()
+	runtimeUID := strconv.Itoa(runtimeUIDInt)
+	runtimeGIDInt := os.Getgid()
+	runtimeGID := strconv.Itoa(runtimeGIDInt)
+
+	// only run once on the system
+	if _, err := os.Stat(ranFile); !os.IsNotExist(err) {
+		logInfo("already ran on this system; will not attempt to change UID/GID")
+		exitOrExec(runtimeUID, runtimeUIDInt, runtimeGIDInt, -1, argsWithoutProg)
+	}
+
+	// check that script is running as root
+	if os.Geteuid() != 0 {
+		logger.Fatalln(`fixids is not running as root, ensure that the following criteria are met:
+        - fixids binary is owned by root: 'chown root:root /path/to/fixids'
+        - fixids binary has the setuid bit: 'chmod u+s /path/to/fixids'
+        - NoNewPrivileges is disabled in container security profile
+        - volume containing fixids binary does not have the 'nosuid' mount option`)
+	}
+
+	// validate the container user from the config
+	containerUser := argsWithoutProg[0]
+
+	containerUID, containerUIDError := findUID(containerUser)
+	if containerUIDError != nil {
+		logger.Fatalln(containerUIDError)
+	}
+	if containerUID == "" {
+		logger.Fatalln("user '" + containerUser + "' does not exist")
+	}
+	containerUIDInt, err := strconv.Atoi(containerUID)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	containerUIDUint32 := uint32(containerUIDInt) //nolint:gosec
+
+	containerGroup := argsWithoutProg[1]
+	containerGID, containerGIDError := findGID(containerGroup)
+	if containerGIDError != nil {
+		logger.Fatalln(containerGIDError)
+	}
+	if containerGID == "" {
+		logger.Fatalln("group '" + containerGroup + "' does not exist")
+	}
+	containerGIDInt, err := strconv.Atoi(containerGID)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	containerGIDUint32 := uint32(containerGIDInt) //nolint:gosec
+
+	argsWithoutProg = argsWithoutProg[2:]
+
+	home, err := findHomeDir(containerUID)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	paths := []string{home, cwd}
+
+	// declare uid/gid vars and
+	var oldUID, newUID, oldGID, newGID string
+	needChown := false
+
+	// decide if need to change UIDs
+	existingUser, existingUserError := findUser(runtimeUID)
+	if existingUserError != nil {
+		logger.Fatalln(existingUserError)
+	}
+	if existingUser == "" {
+		logInfo("updating user '" + containerUser + "' to UID '" + runtimeUID + "'")
+		needChown = true
+		oldUID = containerUID
+		newUID = runtimeUID
+	} else {
+		oldUID = ""
+		newUID = ""
+		if existingUser == containerUser {
+			logInfo("runtime UID '" + runtimeUID + "' already matches container user '" + containerUser + "' UID")
+		} else {
+			logInfo("runtime UID '" + runtimeUID + "' matches existing user '" + existingUser + "'; not changing UID")
+			needChown = true
+		}
+	}
+
+	// decide if need to change GIDs
+	existingGroup, existingGroupError := findGroup(runtimeGID)
+	if existingGroupError != nil {
+		logger.Fatalln(existingGroupError)
+	}
+	if existingGroup == "" {
+		logInfo("updating group '" + containerGroup + "' to GID '" + runtimeGID + "'")
+		needChown = true
+		oldGID = containerGID
+		newGID = runtimeGID
+	} else {
+		oldGID = ""
+		newGID = ""
+		if existingGroup == containerGroup {
+			logInfo("runtime GID '" + runtimeGID + "' already matches container group '" + containerGroup + "' GID")
+		} else {
+			logInfo("runtime GID '" + runtimeGID + "' matches existing group '" + existingGroup + "'; not changing GID")
+			needChown = true
+		}
+	}
+
+	// update /etc/passwd if necessary
+	if oldUID != newUID || oldGID != newGID {
+		err := updateEtcPasswd(containerUser, oldUID, newUID, oldGID, newGID)
+		if err != nil {
+			logger.Fatalln(err)
+		}
+	}
+
+	// update /etc/group if necessary
+	if oldGID != newGID {
+		err := updateEtcGroup(containerGroup, oldGID, newGID)
+		if err != nil {
+			logger.Fatalln(err)
+		}
+	}
+
+	// search entire filesystem and chown containerUID:containerGID to runtimeUID:runtimeGID
+	if needChown {
+
+		// process /proc/mounts
+		mounts, err := parseProcMounts()
+		if err != nil {
+			logger.Fatalln(err)
+		}
+
+		// store the current mountpoint
+		var mountpoint string
+
+		// this function is called for every file visited
+		visit := func(filePath string, fileInfo os.FileInfo, err error) error {
+
+			// an error to lstat or filepath.readDirNames
+			// see https://github.com/boxboat/fixids/issues/4
+			if err != nil {
+				logInfo("error when visiting " + filePath)
+				logInfo(err)
+				return nil
+			}
+
+			// stat file to determine UID and GID
+			sys, ok := fileInfo.Sys().(*syscall.Stat_t)
+			if !ok {
+				logInfo("cannot stat " + filePath)
+				return filepath.SkipDir
+			}
+
+			// prevent recursing into mounts
+			if findMountpoint(filePath, mounts) != mountpoint {
+				if sys.Uid == containerUIDUint32 && sys.Gid == containerGIDUint32 {
+					logInfo("skipping mounted path " + filePath)
+				}
+				if fileInfo.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			// only chown if file is containerUID:containerGID
+			if sys.Uid == containerUIDUint32 && sys.Gid == containerGIDUint32 {
+				logInfo("chown " + filePath)
+				err := syscall.Lchown(filePath, runtimeUIDInt, runtimeGIDInt)
+				if err != nil {
+					logInfo("error changing owner of " + filePath)
+					logInfo(err)
+				}
+				return nil
+			}
+			return nil
+		}
+
+		for _, path := range paths {
+			// stat the path to ensure it exists
+			_, err := os.Stat(path)
+			if err != nil {
+				logInfo("error accessing path: " + path)
+				logInfo(err)
+				continue
+			}
+			mountpoint = findMountpoint(path, mounts)
+
+			logInfo("recursively searching path " + path)
+			filepath.Walk(path, visit) //nolint:errcheck
+		}
+
+	}
+
+	// mark the script as ran
+	if err := os.WriteFile(ranFile, []byte{}, 0644); err != nil { //nolint:gosec
+		logger.Fatalln(err)
+	}
+
+	// if the existing HOME directory is "/", change it to the user's home directory
+	existingHomeDir := os.Getenv("HOME")
+	if existingHomeDir == "/" {
+		homeDir, homeDirErr := findHomeDir(runtimeUID)
+		if homeDirErr == nil && homeDir != "" && homeDir != "/" {
+			if len(argsWithoutProg) > 0 {
+				os.Setenv("HOME", homeDir)
+			} else {
+				fmt.Println(`export HOME="` + strings.Replace(homeDir, `"`, `\"`, -1) + `"`)
+			}
+		}
+	}
+
+	oldGIDInt := -1
+	if oldGID != "" && oldGID != newGID {
+		if gid, err := strconv.Atoi(oldGID); err != nil {
+			oldGIDInt = gid
+		}
+	}
+
+	// all done
+	exitOrExec(runtimeUID, runtimeUIDInt, runtimeGIDInt, oldGIDInt, argsWithoutProg)
+}
+
+func logInfo(v ...interface{}) {
+	if !*quietFlag {
+		logger.Println(v...)
+	}
+}
+
+// oldGIDInt should be -1 if the GID was not changed
+func exitOrExec(runtimeUID string, runtimeUIDInt, runtimeGIDInt, oldGIDInt int, argsWithoutProg []string) {
+	if len(argsWithoutProg) > 0 {
+		// exec mode - de-escalate privileges and exec new process
+		binary, err := exec.LookPath(argsWithoutProg[0])
+		if err != nil {
+			logger.Fatalln(err)
+		}
+
+		// get real user
+		user, err := findUser(runtimeUID)
+		if err != nil {
+			logger.Fatalln(err)
+		}
+
+		// set groups
+		if user != "" {
+			// get all existing group IDs
+			existingGIDs, err := syscall.Getgroups()
+			if err != nil {
+				logger.Fatalln(err)
+			}
+
+			// get primary GID from /etc/passwd
+			primaryGID, err := findPrimaryGID(runtimeUID)
+			if err != nil {
+				logger.Fatalln(err)
+			}
+
+			// get supplementary GIDs from /etc/group
+			supplementaryGIDs, err := findUserSupplementaryGIDs(user)
+			if err != nil {
+				logger.Fatalln(err)
+			}
+
+			// add all GIDs to a map
+			allGIDs := append(existingGIDs, primaryGID)
+			allGIDs = append(allGIDs, supplementaryGIDs...)
+			gidMap := make(map[int]struct{})
+			for _, gid := range allGIDs {
+				gidMap[gid] = struct{}{}
+			}
+
+			// remove the old GID if it was changed
+			if oldGIDInt >= 0 {
+				delete(gidMap, oldGIDInt)
+			}
+
+			groups := make([]int, 0, len(gidMap))
+			for gid := range gidMap {
+				groups = append(groups, gid)
+			}
+
+			// set groups
+			err = syscall.Setgroups(groups)
+			if err != nil {
+				logger.Fatalln(err)
+			}
+		}
+
+		// de-escalate the group back to the original
+		if err := syscall.Setegid(runtimeGIDInt); err != nil {
+			logger.Fatalln(err)
+		}
+
+		// de-escalate the user back to the original
+		if err := syscall.Seteuid(runtimeUIDInt); err != nil {
+			logger.Fatalln(err)
+		}
+
+		// exec new process
+		env := os.Environ()
+		if err := syscall.Exec(binary, argsWithoutProg, env); err != nil {
+			logger.Fatalln(err)
+		}
+	}
+
+	// nothing to exec; exit the program
+	os.Exit(0)
+}
+
+func searchColonDelimitedFile(filePath string, search string, searchOffset int, returnOffset int) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		cols := strings.Split(scanner.Text(), ":")
+		if len(cols) < (searchOffset+1) || len(cols) < (returnOffset+1) {
+			continue
+		}
+		if cols[searchOffset] == search {
+			return cols[returnOffset], nil
+		}
+	}
+	return "", nil
+}
+
+func findUID(user string) (string, error) {
+	return searchColonDelimitedFile("/etc/passwd", user, 0, 2)
+}
+
+func findUser(uid string) (string, error) {
+	return searchColonDelimitedFile("/etc/passwd", uid, 2, 0)
+}
+
+// returns -1 if not found
+func findPrimaryGID(uid string) (int, error) {
+	gid, err := searchColonDelimitedFile("/etc/passwd", uid, 2, 3)
+	if err != nil {
+		return -1, err
+	}
+	if gid == "" {
+		return -1, nil
+	}
+	return strconv.Atoi(gid)
+}
+
+func findHomeDir(uid string) (string, error) {
+	return searchColonDelimitedFile("/etc/passwd", uid, 2, 5)
+}
+
+func findGID(group string) (string, error) {
+	return searchColonDelimitedFile("/etc/group", group, 0, 2)
+}
+
+func findGroup(gid string) (string, error) {
+	return searchColonDelimitedFile("/etc/group", gid, 2, 0)
+}
+
+func findUserSupplementaryGIDs(user string) ([]int, error) {
+	// group:pass:gid:users
+	file, err := os.Open("/etc/group")
+	if err != nil {
+		return nil, err
+	}
+
+	var gids []int
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		cols := strings.Split(scanner.Text(), ":")
+		if len(cols) < 4 {
+			continue
+		}
+		users := strings.Split(cols[3], ",")
+		if !slices.Contains(users, user) {
+			continue
+		}
+		gid, err := strconv.Atoi(cols[2])
+		if err != nil {
+			continue
+		}
+		gids = append(gids, gid)
+	}
+	file.Close()
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return gids, nil
+}
+
+func updateEtcPasswd(user string, oldUID string, newUID string, oldGID string, newGID string) error {
+	// user:pass:uid:gid:comment:home dir:shell
+	file, err := os.Open("/etc/passwd")
+	if err != nil {
+		return err
+	}
+
+	newLines := ""
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		cols := strings.Split(scanner.Text(), ":")
+		if len(cols) < 4 {
+			continue
+		}
+		if oldUID != "" && newUID != "" && cols[0] == user && cols[2] == oldUID {
+			cols[2] = newUID
+		}
+		if oldGID != "" && newGID != "" && cols[3] == oldGID {
+			cols[3] = newGID
+		}
+		newLines += strings.Join(cols, ":") + "\n"
+	}
+	file.Close()
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile("/etc/passwd", []byte(newLines), 0644); err != nil { //nolint:gosec
+		return err
+	}
+
+	return nil
+}
+
+func updateEtcGroup(group string, oldGID string, newGID string) error {
+	// group:pass:gid:users
+	file, err := os.Open("/etc/group")
+	if err != nil {
+		return err
+	}
+
+	newLines := ""
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		cols := strings.Split(scanner.Text(), ":")
+		if len(cols) < 3 {
+			continue
+		}
+		if oldGID != "" && newGID != "" && cols[0] == group && cols[2] == oldGID {
+			cols[2] = newGID
+		}
+		newLines += strings.Join(cols, ":") + "\n"
+	}
+	file.Close()
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile("/etc/group", []byte(newLines), 0644); err != nil { //nolint:gosec
+		return err
+	}
+
+	return nil
+}
+
+func parseProcMounts() (map[string]bool, error) {
+	// device mountpoint type options dump fsck
+	// spaces appear as \040
+	file, err := os.Open("/proc/mounts")
+	if err != nil {
+		return nil, err
+	}
+
+	mounts := make(map[string]bool)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		cols := strings.Fields(scanner.Text())
+		if len(cols) >= 2 {
+			mounts[filepath.Clean(strings.Replace(cols[1], "\\040", " ", -1))] = true
+		}
+	}
+	file.Close()
+
+	return mounts, nil
+}
+
+func findMountpoint(path string, mounts map[string]bool) string {
+	path = filepath.Clean(path)
+	var lastPath string
+	for path != lastPath {
+		if _, ok := mounts[path]; ok {
+			return path
+		}
+		lastPath = path
+		path = filepath.Dir(path)
+	}
+	return "/"
+}

--- a/internal/fixids/fixuid-LICENSE
+++ b/internal/fixids/fixuid-LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 BoxBoat Technologies, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal/fixids/fixuid-README.md
+++ b/internal/fixids/fixuid-README.md
@@ -1,0 +1,140 @@
+# fixuid
+
+![Build Status](https://github.com/boxboat/fixuid/workflows/Main/badge.svg)
+
+`fixuid` is a Go binary that changes a Docker container's user/group and file permissions that were set at build time to the UID/GID that the container was started with at runtime.  Primary use case is in development Docker containers when working with host mounted volumes.
+
+`fixuid` was born because there is currently no way to remap host volume UIDs/GIDs from the Docker Engine, [see moby issue 7198](https://github.com/moby/moby/issues/7198) for more details.
+
+Check out [BoxBoat's blog post](https://boxboat.com/2017/07/25/fixuid-change-docker-container-uid-gid/) for a practical explanation of how `fixuid` benefits development teams consisting of multiple developers.
+
+**fixuid should only be used in development Docker containers.  DO NOT INCLUDE in a production container image**
+
+# Overview 
+
+- build a Dockerfile with user/group `dockeruser:dockergroup` that has UID/GID `1000:1000`
+- host is running as UID/GID 1001:1002, host mounted volume has permissions 1001:1002
+- run the docker container with argument `-u 1001:1002` so that container is now running with same UID/GID as host
+- `fixuid` can run as an entrypoint or in a startup script and performs the following:
+  - changes `dockeruser` UID to 1001
+  - changes `dockergroup` GID to 1002
+  - changes all file permissions for old `dockeruser:dockergroup` to 1001:1002
+  - updates $HOME inside container to `dockeruser` $HOME
+- now container UID/GID matches host UID/GID and files created in the container on the host mount will be correct
+
+## Motivation
+
+Common Docker development workflows involve mounting source code into a container via a host volume.  Build tools such as `gradle`, `yarn`, `webpack`, etc. download dependencies and create files in the host mount.
+
+Many times the UID/GID of the build tools running in the Docker container do not match the UID/GID of the mounted host volume, and files generated in the container do not match files in the host volume.  This can lead to problems, such as an IDE running on the host not able to modify a file that was created by the container due to a file ownership mismatch.
+
+In large development teams, it is possible to have many developers running as different UIDs/GIDs on their host systems.  With `fixuid`, individual developers can run the same container using the appropriate UID/GID for their host environment.
+
+## Install fixuid in Dockerfile
+
+1. Create a non-root user and group inside of your docker container.  Use any UID/GID, 1000:1000 is a good choice.
+
+    Note: some images already create UID/GID 1000:1000 for you, e.g. `nodejs` creates user/group `node:node` as UID/GID 1000:1000.  In this case you can skip this step and use the `node:node` user/group.
+
+```
+# sample command to create user/group on different base images
+# creates user "docker" with UID 1000, home directory /home/docker, and shell /bin/sh
+# creates group "docker" with GID 1000
+
+# alpine
+RUN addgroup -g 1000 docker && \
+    adduser -u 1000 -G docker -h /home/docker -s /bin/sh -D docker
+    
+# debian / ubuntu
+RUN addgroup --gid 1000 docker && \
+    adduser --uid 1000 --ingroup docker --home /home/docker --shell /bin/sh --disabled-password --gecos "" docker
+
+# centos / fedora
+RUN groupadd -g 1000 docker && \
+    useradd -u 1000 -g docker -d /home/docker -s /bin/sh docker
+```
+
+2. Install `fixuid` in the container, ensure that root owns the file, make it execuatble, and enable the [setuid bit](https://en.wikipedia.org/wiki/Setuid).  Create the file `/etc/fixuid/config.yml` with two lines, `user: <user>` and `group: <group>` using the user and group from step 1.
+
+    Note: this command must be run as root and requires that `curl` is installed in the container
+
+```
+RUN USER=docker && \
+    GROUP=docker && \
+    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+```
+
+3. Set the default user/group to `user:group` and set the entrypoint to `fixuid`.
+
+```
+USER docker:docker
+ENTRYPOINT ["fixuid"]
+```
+
+4. Run the container using UID/GID of your host.  Replace `1000:1000` with your host's `UID/GID`:
+
+```
+docker run --rm -it -u 1000:1000 <image name> sh
+```
+
+## Set Default Values inside of Docker Compose
+
+Set a default UID and GID for the container to run as inside of the `docker-compose.yml` file.  Developers who are running as a different UID/GID on their host can override the defaults using environment variables or a [.env file](https://docs.docker.com/compose/env-file/)
+
+```
+nginx:
+  image: my-nginx
+  user: ${FIXUID:-1000}:${FIXGID:-1000}
+  volumes:
+    - ./nginx:/etc/nginx
+    - ./www:/var/www
+```
+
+## Specify Paths and Behavior across Devices
+
+The default behavior of `fixuid` is to start at the root path `/` and recursively scan each file and directory on the same devices as `/`.  In the configuration file `/etc/fixuid/config.yml`, you can specify specify the directories that should be recursively scanned:
+
+```yaml
+user: docker
+group: docker
+paths:
+  - /home/docker
+  - /tmp
+```
+
+`fixuid` will only recurse into a directory as long as it is on the same initial device specified in `paths` and will not recurse into directories mounted on other devices.  This includes Docker volumes.  If you want `fixuid` to run on the root Docker filesystem and a Docker volume at `/home/docker/.cache`, your configuration should include:
+
+```yaml
+user: docker
+group: docker
+paths:
+  - /
+  - /home/docker/.cache
+```
+
+## Run in Startup Script instead of Entrypoint
+
+You can run `fixuid` as part of your container's startup script.  `fixuid` will `export HOME=/path/to/home` if $HOME is the default value of `/`, so be sure to evaluate the output of `fixuid` when running as a script.  Supplementary groups will not be set in this mode.
+
+```
+#!/bin/sh
+
+# UID/GID map to unknown user/group, $HOME=/ (the default when no home directory is defined)
+
+eval $( fixuid )
+
+# UID/GID now match user/group, $HOME has been set to user's home directory
+```
+
+## Command-Line Flags
+
+`fixuid` has the following command-line flags:
+
+```
+Usage of ./fixuid:
+  -q	quiet mode
+```

--- a/releases/v0.15.0.md
+++ b/releases/v0.15.0.md
@@ -1,4 +1,4 @@
-**xk6** `v0.20.0` is here! 🎉
+**xk6** `v0.15.0` is here! 🎉
  
 This release includes:
   * Release Docker images using GoReleaser

--- a/releases/v0.20.0.md
+++ b/releases/v0.20.0.md
@@ -9,6 +9,29 @@ This release includes:
 
 The well-known [GoReleaser](https://github.com/goreleaser/goreleaser) tool is already used for releasing xk6 binary. Docker images are now also released with GoReleaser.
 
+In addition to simplifying the release workflow, the main benefit is that Docker images are now available with major and minor version tags.
+
+For example, let's say `1.2.3` is the latest xk6 Docker image version.
+- the latest release of major version `1` is available using the `v1` tag:
+  ```bash
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1
+  ```
+- the latest release of minor version `1.2` is available using the `v1.2` tag:
+  ```bash
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1.2
+  ```
+- of course version `1.2.3` is still available using the `v1.2.3` tag:
+  ```bash
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1.2.3
+  ```
+- the latest release is still available using the `latest` tag:
+  ```bash
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@latest
+  ```
+
+> [!IMPORTANT]
+> In CI pipelines it is recommended to use the major version tag (or the minor version tag) instead of the latest tag. Using the `latest` tag ignores the benefits of semantic versioning and can easily break the CI pipeline.
+
 ## Risks
 
 The following changes are not breaking changes but are risky.

--- a/releases/v0.20.0.md
+++ b/releases/v0.20.0.md
@@ -1,0 +1,27 @@
+**xk6** `v0.20.0` is here! 🎉
+ 
+This release includes:
+  * Release Docker images using GoReleaser
+
+## New Features
+
+### Use GoReleaser to release docker images [#145](https://github.com/grafana/xk6/issues/145)
+
+The well-known [GoReleaser](https://github.com/goreleaser/goreleaser) tool is already used for releasing xk6 binary. Docker images are now also released with GoReleaser.
+
+## Risks
+
+The following changes are not breaking changes but are risky.
+
+### fixuid has been copied to the xk6 repo
+
+The [fixuid](github.com/boxboat/fixuid) tool was used by the xk6 Docker image to modify the user id and group id at runtime in order to make using the Docker image more convenient.
+
+It was copied based on the following considerations:
+- The fixuid is a **security-critical** component of the Docker image
+- The fixuid has a **low release frequency** (last release in **2023**).
+- Using fixuid in the xk6 Docker image is **unnecessarily complicated** (config file generation)
+
+The source of the `fixuid` tool has been copied as an internal `fixids` tool to the `internal/fixids` folder. A minor refactoring has been done for easier usability. The refactor affected parameter/configuration management, not functionality.
+
+**This refactor is worth mentioning because of its risk.** That's why this release is made from only the changes to the Docker image release.


### PR DESCRIPTION
## New Features

### Use GoReleaser to release docker images [#145](https://github.com/grafana/xk6/issues/145)

The well-known [GoReleaser](https://github.com/goreleaser/goreleaser) tool is already used for releasing xk6 binary. Docker images are now also released with GoReleaser.

In addition to simplifying the release workflow, the main benefit is that Docker images are now available with major and minor version tags.

For example, let's say `1.2.3` is the latest xk6 Docker image version.
- the latest release of major version `1` is available using the `v1` tag:
  ```bash
  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1
  ```
- the latest release of minor version `1.2` is available using the `v1.2` tag:
  ```bash
  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1.2
  ```
- of course version `1.2.3` is still available using the `v1.2.3` tag:
  ```bash
  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1.2.3
  ```
- the latest release is still available using the `latest` tag:
  ```bash
  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@latest
  ```

> [!IMPORTANT]
> In CI pipelines it is recommended to use the major version tag (or the minor version tag) instead of the latest tag. Using the `latest` tag ignores the benefits of semantic versioning and can easily break the CI pipeline.

## Risks

The following changes are not breaking changes but are risky.

### fixuid has been copied to the xk6 repo

The [fixuid](github.com/boxboat/fixuid) tool was used by the xk6 Docker image to modify the user id and group id at runtime in order to make using the Docker image more convenient.

It was copied based on the following considerations:
- The fixuid is a **security-critical** component of the Docker image
- The fixuid has a **low release frequency** (last release in **2023**).
- Using fixuid in the xk6 Docker image is **unnecessarily complicated** (config file generation)

The source of the `fixuid` tool has been copied as an internal `fixids` tool to the `internal/fixids` folder. A minor refactoring has been done for easier usability. The refactor affected parameter/configuration management, not functionality.

**This refactor is worth mentioning because of its risk.** That's why new release will be made from only the changes to the Docker image release.