### PR TITLE
xk6 Builder API removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ The [`go-depsync`](https://github.com/grafana/go-depsync/) tool can check for th
 
 >[!IMPORTANT]
 > **Breaking change**
-> As of `v0.16.0`, library usage is not supported!
+>
+> As of `v0.16.0`, xk6 library usage is not supported!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -213,21 +213,9 @@ The [`go-depsync`](https://github.com/grafana/go-depsync/) tool can check for th
 
 ## Library usage
 
-
->Breaking changes since v0.14.0:
-> - `xk6.Builder.Build` function no longer reads environment variables to complete missing attributes. Use `xk6.FromOSEnv()` to create a builder from environment variables and then complete or override attributes as needed.
-> - Dependencies and replacements are now defined as arrays of strings following go mod path replacement format
-
-```go
-// create builder with defaults from environment variables
-builder := xk6.FromOSEnv()
-
-// complete/override attributes
-builder.K6Version = "v0.35.0",
-builder.Extensions = []string{"github.com/grafana/xk6-browser@v0.1.1"},
-
-err := builder.Build(context.Background(), log. "./k6")
-```
+>[!IMPORTANT]
+> **Breaking change**
+> As of `v0.16.0`, library usage is not supported!
 
 ---
 

--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -26,7 +26,7 @@ import (
 	"runtime"
 	"strings"
 
-	"go.k6.io/xk6"
+	"go.k6.io/xk6/internal/legacy"
 )
 
 var (
@@ -76,7 +76,7 @@ func runBuild(ctx context.Context, log *slog.Logger, args []string) error {
 		return fmt.Errorf("parsing options %w", err)
 	}
 
-	builder := xk6.FromOSEnv()
+	builder := legacy.FromOSEnv()
 	if opts.K6Version != "" {
 		builder.K6Version = opts.K6Version
 	}
@@ -187,7 +187,7 @@ func runDev(ctx context.Context, log *slog.Logger, args []string) error {
 	importPath := normalizeImportPath(currentModule, cwd, moduleDir)
 
 	// create a builder with options from environment variables
-	builder := xk6.FromOSEnv()
+	builder := legacy.FromOSEnv()
 
 	// set the current module as dependency
 	builder.Extensions = []string{importPath}

--- a/internal/legacy/builder.go
+++ b/internal/legacy/builder.go
@@ -1,5 +1,5 @@
-// Package xk6 contains the xk6 builder API.
-package xk6
+// Package legacy contains the legacy xk6 builder API.
+package legacy
 
 import (
 	"context"

--- a/internal/legacy/builder_internal_test.go
+++ b/internal/legacy/builder_internal_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package xk6
+package legacy
 
 import (
 	"reflect"

--- a/internal/legacy/platforms.go
+++ b/internal/legacy/platforms.go
@@ -1,4 +1,4 @@
-package xk6
+package legacy
 
 import (
 	"encoding/json"

--- a/releases/v0.16.0.md
+++ b/releases/v0.16.0.md
@@ -1,15 +1,15 @@
 **xk6** `v0.16.0` is here! 🎉
  
 This release includes:
-- xk6 Builder API removed
+- Public xk6 Builder API removed
 - New golangci-lint configuration
 - New Dependabot configuration
 
 ## Breaking changes
 
-### xk6 Builder API removed [#146](https://github.com/grafana/xk6/issues/146)
+### Public xk6 Builder API removed [#146](https://github.com/grafana/xk6/issues/146)
 
-There was no real need for the xk6 Builder API. The refactoring of xk6 makes it difficult to provide the Builder API, so it was removed.
+There was no real need for the public xk6 Builder API. The refactoring of xk6 makes it difficult to provide the API, so it was moved to the `internal` package.
 
 ## Maintenance
 

--- a/releases/v0.16.0.md
+++ b/releases/v0.16.0.md
@@ -1,9 +1,17 @@
-**xk6** `vx.y.z` is here! 🎉
+**xk6** `v0.16.0` is here! 🎉
  
 This release includes:
+- xk6 Builder API removed
 - New golangci-lint configuration
+- New Dependabot configuration
 
-## New features
+## Breaking changes
+
+### xk6 Builder API removed [#146](https://github.com/grafana/xk6/issues/146)
+
+There was no real need for the xk6 Builder API. The refactoring of xk6 makes it difficult to provide the Builder API, so it was removed.
+
+## Maintenance
 
 ### New golangci-lint configuration [#149](https://github.com/grafana/xk6/issues/149)
 
@@ -15,3 +23,11 @@ Principles taken into account when creating the configuration:
 - Disabling a rule should be justified in a comment.
 
 The xk6 source code has be modified to comply with the new rules.
+
+### New Dependabot configuration [#160](https://github.com/grafana/xk6/issues/160)
+
+Dependabot has been configured to keep the following dependencies up to date:
+- go packages
+- Docker base images
+- Dev Container features
+- GitHub Actions


### PR DESCRIPTION
There was no real need for the xk6 Builder API. The refactoring of xk6 makes it difficult to provide the Builder API, so it was removed.
