### PR TITLE
Remove v prefix from Docker tags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,14 +52,14 @@ dockers:
     use: buildx
     extra_files: ["docker-entrypoint.sh"]
     image_templates:
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Tag }}-amd64"
-      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}-amd64"
-      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Version }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-amd64"
       - "docker.io/{{ .Env.IMAGE }}:latest-amd64"
 
-      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Tag }}-amd64"
-      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}-amd64"
-      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Version }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-amd64"
       - "ghcr.io/{{ .Env.IMAGE }}:latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
@@ -75,14 +75,14 @@ dockers:
     use: buildx
     extra_files: ["docker-entrypoint.sh"]
     image_templates:
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Tag }}-arm64"
-      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}-arm64"
-      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Version }}-arm64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}-arm64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-arm64"
       - "docker.io/{{ .Env.IMAGE }}:latest-arm64"
 
-      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Tag }}-arm64"
-      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}-arm64"
-      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Version }}-arm64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}-arm64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-arm64"
       - "ghcr.io/{{ .Env.IMAGE }}:latest-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
@@ -95,20 +95,20 @@ dockers:
 
 docker_manifests:
   - id: tag
-    name_template: "docker.io/{{ .Env.IMAGE }}:{{ .Tag }}"
+    name_template: "docker.io/{{ .Env.IMAGE }}:{{ .Version }}"
     image_templates:
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Tag }}-amd64"
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Tag }}-arm64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Version }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Version }}-arm64"
   - id: major
-    name_template: "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}"
+    name_template: "docker.io/{{ .Env.IMAGE }}:{{ .Major }}"
     image_templates:
-      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}-amd64"
-      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}-arm64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}-arm64"
   - id: major-minor
-    name_template: "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}"
+    name_template: "docker.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}"
     image_templates:
-      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-amd64"
-      - "docker.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-amd64"
+      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-arm64"
   - id: latest
     name_template: "docker.io/{{ .Env.IMAGE }}:latest"
     image_templates:
@@ -116,20 +116,20 @@ docker_manifests:
       - "docker.io/{{ .Env.IMAGE }}:latest-arm64"
 
   - id: tag-ghcr
-    name_template: "ghcr.io/{{ .Env.IMAGE }}:{{ .Tag }}"
+    name_template: "ghcr.io/{{ .Env.IMAGE }}:{{ .Version }}"
     image_templates:
-      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Tag }}-amd64"
-      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Tag }}-arm64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Version }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Version }}-arm64"
   - id: major-ghcr
-    name_template: "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}"
+    name_template: "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}"
     image_templates:
-      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}-amd64"
-      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}-arm64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}-arm64"
   - id: major-minor-ghcr
-    name_template: "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}"
+    name_template: "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}"
     image_templates:
-      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-amd64"
-      - "ghcr.io/{{ .Env.IMAGE }}:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-arm64"
   - id: latest-ghcr
     name_template: "ghcr.io/{{ .Env.IMAGE }}:latest"
     image_templates:

--- a/README.md
+++ b/README.md
@@ -31,21 +31,21 @@ If you prefer to setup Go and use xk6 without Docker, see the "Local Installatio
 Docker images can be used with major version, minor version, and specific version tags.
 
 For example, let's say `1.2.3` is the latest xk6 Docker image version.
-- the latest release of major version `1` is available using the `v1` tag:
+- the latest release of major version `1` is available using the `1` tag:
   ```bash
-  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6:1
   ```
-- the latest release of minor version `1.2` is available using the `v1.2` tag:
+- the latest release of minor version `1.2` is available using the `1.2` tag:
   ```bash
-  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1.2
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6:1.2
   ```
 - of course version `1.2.3` is still available using the `v1.2.3` tag:
   ```bash
-  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@v1.2.3
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6:1.2.3
   ```
 - the latest release is still available using the `latest` tag:
   ```bash
-  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6@latest
+  docker run --rm -it -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6:latest
   ```
 
 > [!IMPORTANT]

--- a/releases/v0.16.1.md
+++ b/releases/v0.16.1.md
@@ -1,0 +1,10 @@
+**xk6** `v0.16.1` is here! 🎉
+ 
+This release includes:
+- Remove v prefix from Docker tags
+
+## Bug fixes
+
+### Remove v prefix from Docker tags [#164](https://github.com/grafana/xk6/issues/164)
+
+Starting with `v0.15.0`, Docker images are built with goreleaser. A `v` prefix was accidentally added to the beginning of the Docker version tags. This has been fixed, and the Docker image version tags will no longer have the `v` prefix.


### PR DESCRIPTION
Starting with `v0.15.0`, Docker images are built with goreleaser. A `v` prefix was accidentally added to the beginning of the Docker version tags. This has been fixed, and the Docker image version tags will no longer have the `v` prefix.