### PR TITLE
Enable early access functionality via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >[!IMPORTANT]
 > **Upcoming changes**
 >
-> The xk6 tool is currently under refactoring. As of `v0.17.0`, an early access executable (`xk6ea`) is available in the downloadable release archives alongside `xk6`. Check [READMEea.md](READMEea.md) for usage.
+> The xk6 tool is currently under refactoring. As of `v0.17.0`, an early access executable (`xk6ea`) is available in the downloadable release archives alongside `xk6`. As of `v0.18.0`, early access functionality is also included in the `xk6` executable, which can be activated by setting the `XK6_EARLY_ACCESS` environment variable to `true`. Check [READMEea.md](READMEea.md) for usage.
 
 This command line tool and associated Go package makes it easy to make custom builds of [k6](https://github.com/grafana/k6).
 

--- a/cmd/xk6/main.go
+++ b/cmd/xk6/main.go
@@ -26,6 +26,7 @@ import (
 	"runtime"
 	"strings"
 
+	"go.k6.io/xk6/internal/cmd"
 	"go.k6.io/xk6/internal/legacy"
 )
 
@@ -48,6 +49,12 @@ type buildOps struct {
 //
 //nolint:gocritic
 func main() {
+	if os.Getenv("XK6_EARLY_ACCESS") == "true" {
+		cmd.Execute()
+
+		return
+	}
+
 	log := slog.Default()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/releases/v0.18.0.md
+++ b/releases/v0.18.0.md
@@ -2,9 +2,16 @@
  
 This release includes:
   - `lint` subcommand
+  - early access functionality in `xk6`
 
 ## New features
 
 ### `lint` subcommand [#151](https://github.com/grafana/xk6/issues/151)
 
 The [grafana/k6lint](https://github.com/grafana/k6lint) k6 extension linter has been moved as `xk6 lint` subcommand. The `lint` subcommand is available in the early access (`xk6ea`) executable. As of `v0.17.0`, an early access executable (`xk6ea`) is available in the downloadable release archives alongside `xk6`. Check `READMEea.md` for usage.
+
+### Early access functionality can be activated via environment variable [#169](https://github.com/grafana/xk6/issues/169)
+
+In some situations, it is difficult to install another binary (`xk6ea`) (e.g. Development containers). In such situations, it is easier if `xk6` includes early access functionality and can be activated via an environment variable.
+
+Early access functionality is now included in the `xk6` executable, which can be activated by setting the `XK6_EARLY_ACCESS` environment variable to `true`. The early access executable (`xk6ea`) is still available in the release.


### PR DESCRIPTION
In some situations, it is difficult to install another binary (`xk6ea`) (e.g. Development containers). In such situations, it is easier if `xk6` includes early access functionality and can be activated via an environment variable.

Early access functionality is now included in the `xk6` executable, which can be activated by setting the `XK6_EARLY_ACCESS` environment variable to `true`. The early access executable (`xk6ea`) is still available in the release.
