### PR TITLE
Fix default golangci-lint arguments

### DIFF
--- a/.github/workflows/extension-validate.yml
+++ b/.github/workflows/extension-validate.yml
@@ -179,7 +179,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         with:
           version: "${{ inputs.golangci-lint-version }}"
-          args: --timeout=30m --no-config --presets bugs --enable gofmt
+          args: --timeout=30m --no-config
 
       - name: Run configured golangci-lint ${{ inputs.golangci-lint-version }}
         if: ${{ hashFiles('.golangci.yml','.golangci.yaml','.golangci.toml','.golangci.json') != ''}}

--- a/.github/workflows/tooling-validate.yml
+++ b/.github/workflows/tooling-validate.yml
@@ -126,7 +126,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         with:
           version: "${{ inputs.golangci-lint-version }}"
-          args: --timeout=30m --no-config --presets bugs --enable gofmt
+          args: --timeout=30m --no-config
 
       - name: Run configured golangci-lint ${{ inputs.golangci-lint-version }}
         if: ${{ hashFiles('.golangci.yml','.golangci.yaml','.golangci.toml','.golangci.json') != ''}}

--- a/releases/v0.19.1.md
+++ b/releases/v0.19.1.md
@@ -1,0 +1,10 @@
+**xk6** `v0.19.1` is here!
+
+This is a minor bugfix release for reusable GitHub workflows:
+
+**Fix default golangci-lint arguments**
+
+The `--preset` flag has been deprecated since golangci-lint version 2.
+Validate workflows used the `--preset` flag when there is no golangci-lint configuration file.
+This caused an error, so the `--preset` flag has been removed from the default arguments.
+


### PR DESCRIPTION
The `--preset` flag has been deprecated since golangci-lint version 2.
Validate workflows used the `--preset` flag when there is no golangci-lint configuration file.
This caused an error, so the `--preset` flag has been removed from the default arguments.
