### PR TITLE
add gh cli extension support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,8 @@ builds:
     ldflags:
       - "-s -w"
       - "-X {{.ModulePath}}/internal/cmd.version={{.Version}}"
-      - "-X {{.ModulePath}}/internal/cmd.appname={{.Binary}}"
+      - "-X {{.ModulePath}}/internal/cmd.appname={{.ProjectName}}"
+      - "-X {{.ModulePath}}/internal/cmd.binary={{.Binary}}"
     hooks:
       post:
         - cp "{{ .Path }}" it/xk6
@@ -34,7 +35,8 @@ builds:
     ldflags:
       - "-s -w"
       - "-X {{.ModulePath}}/internal/cmd.version={{.Version}}"
-      - "-X {{.ModulePath}}/internal/cmd.appname={{.Binary}}"
+      - "-X {{.ModulePath}}/internal/cmd.appname={{.ProjectName}}"
+      - "-X {{.ModulePath}}/internal/cmd.binary={{.Binary}}"
     hooks:
       post:
         - cp "{{ .Path }}" it/xk6
@@ -47,6 +49,20 @@ builds:
     flags: ["-trimpath"]
     env: ["CGO_ENABLED=0"]
     ldflags: ["-s -w"]
+
+  - id: gh-xk6
+    no_unique_dist_dir: true
+    binary: "gh-xk6/gh-xk6_{{ .Tag }}_{{ .Os }}-{{ .Arch }}{{if .Arm}}_{{.Arm}}{{end}}"
+    main: .
+    goos: ["linux", "windows", "darwin"]
+    goarch: ["amd64", "arm64"]
+    flags: ["-trimpath"]
+    env: ["CGO_ENABLED=0"]
+    ldflags:
+      - "-s -w"
+      - "-X {{.ModulePath}}/internal/cmd.version={{.Version}}"
+      - "-X {{.ModulePath}}/internal/cmd.appname={{.ProjectName}}"
+      - "-X {{.ModulePath}}/internal/cmd.binary=gh-xk6"
 
 source:
   enabled: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,7 +70,7 @@ source:
 
 archives:
   - id: bundle
-    builds: ["xk6", "xk6legacy"]
+    ids: ["xk6", "xk6legacy"]
     formats: ["tar.gz"]
     format_overrides:
       - goos: windows

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -56,7 +56,8 @@ func trapSignals(ctx context.Context, cancel context.CancelFunc) {
 var (
 	version = ""
 	appname = "xk6"
-	binary  = appname
+	// Note that binary = appname will not work because ldflags inserts the values to the same place.
+	binary = "xk6"
 )
 
 //go:embed help/root.md

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/lmittmann/tint"
@@ -55,6 +56,7 @@ func trapSignals(ctx context.Context, cancel context.CancelFunc) {
 var (
 	version = ""
 	appname = "xk6"
+	binary  = appname
 )
 
 //go:embed help/root.md
@@ -72,6 +74,10 @@ func New(levelVar *slog.LevelVar) *cobra.Command {
 		SilenceErrors:     true,
 		DisableAutoGenTag: true,
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+	}
+
+	if binary != appname {
+		root.Annotations = map[string]string{cobra.CommandDisplayNameAnnotation: strings.ReplaceAll(binary, "-", " ")}
 	}
 
 	flags := root.Flags()

--- a/releases/v0.19.3.md
+++ b/releases/v0.19.3.md
@@ -1,0 +1,5 @@
+**xk6** `v0.19.3` is here!
+
+This is a maintenance release, changes:
+
+- added gh CLI extension support [#186](https://github.com/grafana/xk6/issues/186)


### PR DESCRIPTION
Although the xk6 [GitHub CLI](https://cli.github.com/) extension will be distributed in the [gh-xk6](https://github.com/grafana/gh-xk6) repository, in order to use the xk6 binary as a GitHub CLI extension, a minimum level of support is required:

- configure goreleaser to also build binaries with the gh CLI naming convention
- if xk6 is run as a gh CLI subcommand, the help should be displayed accordingly.