### PR TITLE
Ensure arm64 image contains native binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,6 +68,8 @@ snapshot:
 
 dockers:
   - id: amd64
+    goos: linux
+    goarch: amd64
     ids: ["xk6", "fixids"]
     dockerfile: Dockerfile.goreleaser
     use: buildx
@@ -91,6 +93,8 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.licenses=AGPL-3.0-only"
   - id: arm64
+    goos: linux
+    goarch: arm64
     ids: ["xk6", "fixids"]
     dockerfile: Dockerfile.goreleaser
     use: buildx

--- a/releases/v1.1.1.md
+++ b/releases/v1.1.1.md
@@ -1,0 +1,10 @@
+Grafana **xk6** `v1.1.1` is here! 🎉
+
+This is a patch release that addresses a critical bug in our multi-arch Docker image, ensuring proper functionality on `arm64` platforms.
+
+## Bug Fix
+
+Corrected the build process for the `linux/arm64` Docker image. Previously, the image was incorrectly shipping `amd64` binaries, causing an `exec format error` on ARM-based systems like Apple Silicon (M1/M2/M3) and AWS Graviton. The multi-arch image now contains the correct native binaries for the `arm64` platform and functions as expected.
+
+This resolves the issue where running `xk6` on an `arm64` host would fail. A big thank you to @potyl for reporting this!
+


### PR DESCRIPTION
Corrected the build process for the `linux/arm64` Docker image. Previously, the image was incorrectly shipping `amd64` binaries, causing an `exec format error` on ARM-based systems like Apple Silicon (M1/M2/M3) and AWS Graviton. The multi-arch image now contains the correct native binaries for the `arm64` platform and functions as expected.