### PR TITLE
Correctly log k6 version during build`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/go-enry/go-license-detector/v4 v4.3.1
 	github.com/go-git/go-git/v5 v5.16.2
-	github.com/grafana/k6foundry v0.4.6
+	github.com/grafana/k6foundry v0.4.7
 	github.com/lmittmann/tint v1.1.2
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8J
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/grafana/k6foundry v0.4.6 h1:fFgR72Pw0dzo8wVWyggu35SGGjdt31Dktil1bDE1MCM=
-github.com/grafana/k6foundry v0.4.6/go.mod h1:eLsr0whhH+5Y1y7YpDxJi3Jv5wHMuf+80vdRyMH10pg=
+github.com/grafana/k6foundry v0.4.7 h1:1YXkTBwO/2dSx0pqJrraJATsFlsIX0vEpaEjV7E35w4=
+github.com/grafana/k6foundry v0.4.7/go.mod h1:eLsr0whhH+5Y1y7YpDxJi3Jv5wHMuf+80vdRyMH10pg=
 github.com/hhatto/gorst v0.0.0-20181029133204-ca9f730cac5b h1:Jdu2tbAxkRouSILp2EbposIb8h4gO+2QuZEn3d9sKAc=
 github.com/hhatto/gorst v0.0.0-20181029133204-ca9f730cac5b/go.mod h1:HmaZGXHdSwQh1jnUlBGN2BeEYOHACLVGzYOXCbsLvxY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"go.k6.io/xk6/internal/sync"
 )
 
 //go:embed help/build.md
@@ -70,6 +71,17 @@ func buildRunE(ctx context.Context, opts *buildOptions) error {
 
 	for name, version := range info.ModVersions {
 		slog.Info("added", "module", name, "version", version)
+	}
+
+	if ok {
+		slog.Info("A new binary has been built based on k6", "version", k6ver)
+	}
+
+	k6latest, err := sync.GetLatestK6Version(ctx)
+	if err == nil && k6ver != k6latest {
+		slog.Warn("Newer k6 version available", "actual", k6ver, "latest", k6latest)
+	} else if err != nil {
+		slog.Warn("Failed to get latest k6 version", "error", err)
 	}
 
 	if !opts.outputChanged {

--- a/internal/cmd/build_helper.go
+++ b/internal/cmd/build_helper.go
@@ -132,9 +132,12 @@ func newFoundry(ctx context.Context, opts *buildOptions) (k6foundry.Foundry, err
 			CopyGoEnv: true,
 			Env:       env,
 		},
-		K6Repo:      opts.k6repo,
 		SkipCleanup: opts.skipCleanup != 0,
 		Logger:      logger,
+	}
+
+	if opts.k6repo != defaultK6Repo { // only set if different from default: k6foundry workaround
+		fopts.K6Repo = opts.k6repo
 	}
 
 	if logger.Enabled(ctx, slog.LevelDebug) {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -73,6 +73,11 @@ func Sync(ctx context.Context, dir string, opts *Options) error {
 	return cmd.Run()
 }
 
+// GetLatestK6Version retrieves the latest version of k6 from the Go proxy.
+func GetLatestK6Version(ctx context.Context) (string, error) {
+	return getLatestVersion(ctx, k6Module)
+}
+
 func diffRequires(extModfile, k6Modfile *modfile.File) []string {
 	patch := make([]string, 0)
 

--- a/vendor/github.com/grafana/k6foundry/catalog-info.yaml
+++ b/vendor/github.com/grafana/k6foundry/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: k6foundry
+  title: k6foundry
+  description: |
+    k6foundry is a CLI for building custom k6 binaries with extensions.
+  annotations:
+    github.com/project-slug: grafana/k6foundry
+spec:
+  type: tool
+  owner: group:default/k6-extensions
+  lifecycle: production

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -148,7 +148,7 @@ github.com/go-git/go-git/v5/utils/trace
 # github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
 ## explicit; go 1.20
 github.com/golang/groupcache/lru
-# github.com/grafana/k6foundry v0.4.6
+# github.com/grafana/k6foundry v0.4.7
 ## explicit; go 1.22.2
 github.com/grafana/k6foundry
 # github.com/hhatto/gorst v0.0.0-20181029133204-ca9f730cac5b


### PR DESCRIPTION

- Updates the `k6foundry` dependency to **v0.4.7**. This resolves a bug where the `xk6 build` command would log an incorrect version of `k6`.
- Warning logging if not the latest k6 version was used for the build

Closes #52 
Closes #236