### PR TITLE
Added xk6 sync output in various formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,10 @@ xk6 sync [flags]
 ```
   -k, --k6-version string   The k6 version to use for synchronization (default from go.mod)
   -n, --dry-run             Do not make any changes, only log them
+  -o, --out string          Write output to file instead of stdout
+      --json                Generate JSON output
+  -c, --compact             Compact instead of pretty-printed JSON output
+  -m, --markdown            Generate Markdown output
 ```
 
 ## Global Flags

--- a/internal/cmd/lint.go
+++ b/internal/cmd/lint.go
@@ -172,7 +172,7 @@ func lintRunE(ctx context.Context, args []string, opts *options) (result error) 
 	return nil
 }
 
-func jsonOutput(compliance *lint.Compliance, output io.Writer, compact bool) error {
+func jsonOutput(compliance any, output io.Writer, compact bool) error {
 	encoder := json.NewEncoder(output)
 
 	if !compact {

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -3,7 +3,13 @@ package cmd
 import (
 	"context"
 	_ "embed"
+	"fmt"
+	"io"
+	"os"
 
+	"github.com/Masterminds/semver/v3"
+	"github.com/fatih/color"
+	"github.com/mattn/go-colorable"
 	"github.com/spf13/cobra"
 	"go.k6.io/xk6/internal/sync"
 )
@@ -14,6 +20,11 @@ var syncHelp string
 type syncOptions struct {
 	k6version string
 	dryRun    bool
+	out       string
+	compact   bool
+	json      bool
+	markdown  bool
+	quiet     bool
 }
 
 func syncCmd() *cobra.Command {
@@ -24,11 +35,12 @@ func syncCmd() *cobra.Command {
 		Short: shortHelp(syncHelp),
 		Long:  syncHelp,
 		Args:  cobra.NoArgs,
+		PreRun: func(cmd *cobra.Command, _ []string) {
+			opts.json = opts.json || opts.compact
+			opts.quiet = cmd.Flags().Lookup("quiet").Changed
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return sync.Sync(cmd.Context(), ".", &sync.Options{
-				DryRun:    opts.dryRun,
-				K6Version: opts.k6version,
-			})
+			return syncRunE(cmd.Context(), opts)
 		},
 		DisableAutoGenTag: true,
 	}
@@ -43,6 +55,120 @@ func syncCmd() *cobra.Command {
 		"The k6 version to use for synchronization (default from go.mod)")
 	flags.BoolVarP(&opts.dryRun, "dry-run", "n", false,
 		"Do not make any changes, only log them")
+	flags.StringVarP(&opts.out, "out", "o", "",
+		"Write output to file instead of stdout")
+	flags.BoolVar(&opts.json, "json", false,
+		"Generate JSON output")
+	flags.BoolVarP(&opts.compact, "compact", "c", false,
+		"Compact instead of pretty-printed JSON output")
+	flags.BoolVarP(&opts.markdown, "markdown", "m", false,
+		"Generate Markdown output")
 
 	return cmd
+}
+
+func syncRunE(ctx context.Context, opts *syncOptions) (problem error) {
+	result, err := sync.Sync(ctx, ".", &sync.Options{
+		DryRun:    opts.dryRun,
+		K6Version: opts.k6version,
+	})
+	if err != nil {
+		return err
+	}
+
+	output := colorable.NewColorableStdout()
+
+	if len(opts.out) > 0 {
+		file, err := os.Create(opts.out)
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			err := file.Close()
+			if problem == nil && err != nil {
+				problem = err
+			}
+		}()
+
+		output = file
+	}
+
+	if opts.quiet {
+		return nil
+	}
+
+	if opts.json {
+		return jsonOutput(result, output, opts.compact)
+	}
+
+	if opts.markdown {
+		return markdownSyncOutput(result, output)
+	}
+
+	textSyncOutput(result, output)
+
+	return nil
+}
+
+func textSyncOutput(result *sync.Result, output io.Writer) {
+	bold := color.New(color.FgHiWhite, color.Bold).SprintfFunc()
+
+	downgrade := color.New(color.FgYellow).FprintfFunc()
+	upgrade := color.New(color.FgGreen).FprintfFunc()
+	plain := color.New(color.FgWhite).FprintfFunc()
+
+	plain(output, "Dependencies have been synchronized with k6 %s.\n\n", bold(result.K6Version))
+
+	plain(output, "Changes\n───────\n")
+
+	for _, change := range result.Changes {
+		fprintf := downgrade
+		symbol := "▼"
+
+		if isUpgrade(change) {
+			fprintf = upgrade
+			symbol = "▲"
+		}
+
+		fprintf(output, "%s %s\n", symbol, change.Module)
+		plain(output, "  %s => %s\n", change.From, change.To)
+	}
+
+	plain(output, "\n")
+}
+
+func isUpgrade(change *sync.Change) bool {
+	to, err := semver.NewVersion(change.To)
+	if err != nil {
+		return false
+	}
+
+	from, err := semver.NewVersion(change.From)
+	if err != nil {
+		return false
+	}
+
+	return to.GreaterThan(from)
+}
+
+func markdownSyncOutput(result *sync.Result, output io.Writer) error {
+	_, err := fmt.Fprintf(output, "Dependencies have been synchronized with k6 `%s`.\n\n", result.K6Version)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(output, "**Changes**\n\n")
+	if err != nil {
+		return err
+	}
+
+	for _, change := range result.Changes {
+		_, err = fmt.Fprintf(output, "- %s\n  `%s` => `%s`\n", change.Module, change.From, change.To)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -25,52 +25,85 @@ const (
 
 var errHTTP = errors.New("HTTP error")
 
+// Change represents a change in a module dependency.
+type Change struct {
+	// Module is the module path.
+	Module string `json:"module,omitempty"`
+	// From is the version being replaced.
+	From string `json:"from,omitempty"`
+	// To is the version being replaced with.
+	To string `json:"to,omitempty"`
+}
+
+// Result represents the result of a synchronization operation.
+type Result struct {
+	// The k6 version used for synchronization.
+	K6Version string `json:"k6_version,omitempty"`
+	// Changes is a list of changes made to the module dependencies.
+	Changes []*Change `json:"changes,omitempty"`
+}
+
 // Sync synchronizes the versions of the module dependencies in the specified directory with k6.
-func Sync(ctx context.Context, dir string, opts *Options) error {
-	slog.Info("Syncing dependencies with k6")
+func Sync(ctx context.Context, dir string, opts *Options) (*Result, error) {
+	slog.Debug("Syncing dependencies with k6")
 
 	extModfile, err := loadModfile(dir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	k6Version, err := getK6Version(ctx, opts, extModfile)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	slog.Info("Target k6", "version", k6Version)
+	slog.Debug("Target k6", "version", k6Version)
 
 	k6Modfile, err := getModule(ctx, k6Module, k6Version)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	patch := diffRequires(extModfile, k6Modfile)
-	if len(patch) == 0 {
-		slog.Info("No changes needed")
+	result := &Result{
+		K6Version: k6Version,
+		Changes:   diffRequires(extModfile, k6Modfile),
+	}
 
-		return nil
+	if len(result.Changes) == 0 {
+		slog.Debug("No changes needed")
+
+		return result, nil
 	}
 
 	if opts.DryRun {
-		slog.Warn("Not saving changes, dry run")
+		slog.Debug("Not saving changes, dry run")
 
-		return nil
+		return result, nil
 	}
 
-	patch = append(patch, "") // make space for the "get" command
-	copy(patch[1:], patch[0:])
-	patch[0] = "get"
+	patch := make([]string, 0, len(result.Changes)+1) // +1 for the "get" command
 
-	slog.Info("Updating go.mod")
+	// Prepare the patch command to update go.mod
+	patch = append(patch, "get")
+
+	// Add each change to the patch command
+	for _, change := range result.Changes {
+		slog.Debug("Updating dependency", "module", change.Module, "from", change.From, "to", change.To)
+		patch = append(patch, fmt.Sprintf("%s@%s", change.Module, change.To))
+	}
+
+	slog.Debug("Updating go.mod")
 
 	cmd := exec.Command("go", patch...) // #nosec G204
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // GetLatestK6Version retrieves the latest version of k6 from the Go proxy.
@@ -78,8 +111,8 @@ func GetLatestK6Version(ctx context.Context) (string, error) {
 	return getLatestVersion(ctx, k6Module)
 }
 
-func diffRequires(extModfile, k6Modfile *modfile.File) []string {
-	patch := make([]string, 0)
+func diffRequires(extModfile, k6Modfile *modfile.File) []*Change {
+	changes := make([]*Change, 0)
 
 	for _, k6Require := range k6Modfile.Require {
 		k6Modpath, k6Modversion := k6Require.Mod.Path, k6Require.Mod.Version
@@ -87,14 +120,16 @@ func diffRequires(extModfile, k6Modfile *modfile.File) []string {
 		for _, extRequire := range extModfile.Require {
 			extModpath, extModversion := extRequire.Mod.Path, extRequire.Mod.Version
 			if k6Modpath == extModpath && k6Modversion != extModversion {
-				slog.Info("Sync", "module", k6Modpath, "from", extModversion, "to", k6Modversion)
-
-				patch = append(patch, fmt.Sprintf("%s@%s", k6Modpath, k6Modversion))
+				changes = append(changes, &Change{
+					Module: k6Modpath,
+					From:   extModversion,
+					To:     k6Modversion,
+				})
 			}
 		}
 	}
 
-	return patch
+	return changes
 }
 
 func getK6Version(ctx context.Context, opts *Options, mf *modfile.File) (string, error) {

--- a/internal/sync/sync_internal_test.go
+++ b/internal/sync/sync_internal_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"reflect"
 	"testing"
 
 	"golang.org/x/mod/modfile"
@@ -45,10 +46,16 @@ func TestDiffRequires_OneDifference(t *testing.T) {
 		},
 	}
 
-	want := []string{"github.com/foo/bar@v1.2.4"}
+	want := []*Change{
+		{
+			Module: "github.com/foo/bar",
+			From:   "v1.2.3",
+			To:     "v1.2.4",
+		},
+	}
 
 	got := diffRequires(ext, k6)
-	if len(got) != 1 || got[0] != want[0] {
+	if reflect.DeepEqual(got, want) == false {
 		t.Errorf("expected %v, got %v", want, got)
 	}
 }
@@ -70,13 +77,22 @@ func TestDiffRequires_MultipleDifferences(t *testing.T) {
 		},
 	}
 
-	want := []string{
-		"github.com/foo/bar@v1.2.4",
-		"github.com/baz/qux@v2.1.0",
+	want := []*Change{
+		{
+			Module: "github.com/foo/bar",
+
+			From: "v1.2.3",
+			To:   "v1.2.4",
+		},
+		{
+			Module: "github.com/baz/qux",
+			From:   "v2.0.0",
+			To:     "v2.1.0",
+		},
 	}
 
 	got := diffRequires(ext, k6)
-	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+	if !reflect.DeepEqual(got, want) {
 		t.Errorf("expected %v, got %v", want, got)
 	}
 }

--- a/releases/v1.1.2.md
+++ b/releases/v1.1.2.md
@@ -1,0 +1,14 @@
+Grafana **xk6** `v1.1.2` is here! 🎉
+
+## Bug Fixes
+
+- The `xk6 build` command now correctly logs the **k6 version** being used. The version number is emphasized, and a warning is displayed if it's not the latest.
+- `xk6 build` now respects `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables, allowing it to work in proxied environments.
+
+## New Feature
+
+The **`xk6 sync`** command can now generate results in multiple formats:
+   * **Terminal text**: The default, colored output.
+   * **JSON**: Use the `--json` flag for standard JSON output or combine it with `--compact` for unindented JSON.
+   * **Markdown**: Use the `--markdown` flag to generate a Markdown report, which is useful for changelogs.
+


### PR DESCRIPTION
The **`xk6 sync`** command can now generate results in multiple formats:
   * **Terminal text**: The default, colored output.
   * **JSON**: Use the `--json` flag for standard JSON output or combine it with `--compact` for unindented JSON.
   * **Markdown**: Use the `--markdown` flag to generate a Markdown report, which is useful for changelogs.
