### PR TITLE
Prepare v1.1.3

### DIFF
--- a/releases/v1.1.3.md
+++ b/releases/v1.1.3.md
@@ -1,0 +1,5 @@
+Grafana **xk6** `v1.1.3` is here! 🎉
+
+Security update: Fixed the following CVEs by updating the Docker base image to `golang:1.24.6-alpine3.22`
+ - CVE-2025-4674
+ - CVE-2025-47907


### PR DESCRIPTION
Security update: Fixed the following CVEs by updating the Docker base image to `golang:1.24.6-alpine3.22`
 - CVE-2025-4674
 - CVE-2025-47907
