### PR TITLE
improve version command to correctly display version

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/lmittmann/tint"
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
@@ -117,33 +118,15 @@ func getVersion() string {
 		return version
 	}
 
-	var (
-		commit string
-		dirty  string
-		suffix string
-	)
-
 	buildInfo, ok := debug.ReadBuildInfo()
 	if ok {
-		for _, s := range buildInfo.Settings {
-			switch s.Key {
-			case "vcs.revision":
-				const shortCommitLen = 7
-				commit = s.Value[:min(len(s.Value), shortCommitLen)]
-			case "vcs.modified":
-				if s.Value == "true" {
-					dirty = ".dirty"
-				}
-			default:
-			}
+		ver, err := semver.NewVersion(buildInfo.Main.Version)
+		if err == nil {
+			return ver.String()
 		}
 	}
 
-	if len(commit) != 0 {
-		suffix = "+" + commit + dirty
-	}
-
-	return "0.0.1-next" + suffix
+	return "0.0.0-devel"
 }
 
 func initLogging() *slog.LevelVar {

--- a/releases/v1.1.4.md
+++ b/releases/v1.1.4.md
@@ -1,0 +1,9 @@
+Grafana **xk6** `v1.1.4` is here! 🎉
+
+This release improves the `version` command and includes automatic dependency updates via dependabot.
+
+## Improved `version` command
+
+Previously, installing with `go install go.k6.io/xk6` caused the `xk6 version` command to display an incorrect version (`0.0.0-next`). This was due to the version being injected at build time as a linker variable by goreleaser.
+
+Now, if the version variable is not injected (such as with `go install`), the version is correctly determined using `debug.BuildInfo`.


### PR DESCRIPTION
Previously, installing with `go install go.k6.io/xk6` caused the `xk6 version` command to display an incorrect version (`0.0.0-next`). This was due to the version being injected at build time as a linker variable by goreleaser.

Now, if the version variable is not injected (such as with `go install`), the version is correctly determined using `debug.BuildInfo`.