### PR TITLE
Support for building private extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ This will install the `xk6` binary in `$GOPATH/bin` directory.
 [Releases]: https://github.com/grafana/xk6/releases
 [stable version]: https://go.dev/dl/
 
+### Building private extensions
+
+To build an `xk6` extension from a private Git repository, you need to configure your environment to handle authentication.
+
+**Core Prerequisite**
+
+First, you must set the **`GOPRIVATE`** environment variable. This tells the Go compiler to bypass the standard Go proxy for your repository, allowing it to access the private module directly.
+
+    export GOPRIVATE=github.com/owner/repo
+
+**Method 1: Using SSH**
+
+To handle authentication in non-interactive environments like CI/CD pipelines, configure Git to use the **SSH protocol** instead of HTTPS. This allows for authentication with an SSH key. This command globally configures Git to rewrite any `https://github.com/` URLs to `ssh://git@github.com/`.
+
+    git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+
+**Method 2: Using GitHub CLI**
+
+An alternative to using SSH is to leverage the **GitHub CLI** as a Git credential helper. In this case, Git will still access the repository over HTTPS, but it will use the GitHub CLI to handle the authentication process, eliminating the need to manually enter a password.
+
+    git config --global --add 'credential.https://github.com.helper' '!gh auth git-credential'
+
 ## Commands
 
 * [xk6 version](#xk6-version)	 - Display version information

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -24,11 +24,11 @@ The [`validate.bats`](../../.github/validate.bats) script is passed as the integ
 
 ```yaml file=../../.github/workflows/validate.yml region=inputs
       go-version: "1.24.x"
-      go-versions: '["1.23.x","1.24.x"]'
+      go-versions: '["1.24.x","1.25.x"]'
       golangci-lint-version: "v2.1.2"
       goreleaser-version: "2.8.2"
       platforms: '["ubuntu-latest", "windows-latest", "macos-latest"]'
-      k6-versions: '["v1.0.0","v0.57.0"]'
+      k6-versions: '["v1.2.3","v1.0.0"]'
       bats: .github/validate.bats
 ```
 
@@ -50,7 +50,7 @@ The [`release.bats`](../../.github/release.bats) script is passed as the integra
 ```yaml file=../../.github/workflows/release.yml region=inputs
       go-version: "1.24.x"
       goreleaser-version: "2.8.2"
-      k6-versions: '["v1.0.0","v0.57.0"]'
+      k6-versions: '["v1.2.3","v1.0.0"]'
       bats: ./.github/release.bats
 ```
 

--- a/internal/cmd/build_helper.go
+++ b/internal/cmd/build_helper.go
@@ -50,9 +50,21 @@ const (
 )
 
 var nonGoEnvToCopy = []string{ //nolint:gochecknoglobals
-	"HTTP_PROXY",
-	"HTTPS_PROXY",
-	"NO_PROXY",
+	"HTTP_PROXY",          // required by git over http(s)
+	"HTTPS_PROXY",         // required by git over http(s)
+	"NO_PROXY",            // required by git over http(s)
+	"SSH_AUTH_SOCK",       // required by git over ssh
+	"SSH_AGENT_PID",       // required by git over ssh
+	"SSH_ASKPASS",         // custom ssh askpass helper
+	"XDG_RUNTIME_DIR",     // required by ssh-agent
+	"USER",                // required by git
+	"HOME",                // required by git
+	"GIT_TERMINAL_PROMPT", // to disable git terminal prompts
+	"GIT_ASKPASS",         // custom git askpass helper
+	"GIT_SSH_COMMAND",     // to pass custom ssh options
+	"GIT_SSH",             // to pass custom ssh options (legacy)
+	"GH_TOKEN",            // GitHub token for GitHub CLI as credential helper
+	"GITHUB_TOKEN",        // GitHub token for GitHub CLI as credential helper
 }
 
 func defaultK6Output() string {

--- a/internal/cmd/help.go
+++ b/internal/cmd/help.go
@@ -19,6 +19,9 @@ var (
 
 	//go:embed help/docker.md
 	dockerHelp string
+
+	//go:embed help/private.md
+	privateHelp string
 )
 
 func helpTopics() []*cobra.Command {
@@ -27,6 +30,7 @@ func helpTopics() []*cobra.Command {
 		helpTopic("devcontainers", devcontainersHelp),
 		helpTopic("docker", dockerHelp),
 		helpTopic("install", installHelp),
+		helpTopic("private", privateHelp),
 	}
 }
 

--- a/internal/cmd/help/private.md
+++ b/internal/cmd/help/private.md
@@ -1,0 +1,21 @@
+Building private extensions
+
+To build an `xk6` extension from a private Git repository, you need to configure your environment to handle authentication.
+
+**Core Prerequisite**
+
+First, you must set the **`GOPRIVATE`** environment variable. This tells the Go compiler to bypass the standard Go proxy for your repository, allowing it to access the private module directly.
+
+    export GOPRIVATE=github.com/owner/repo
+
+**Method 1: Using SSH**
+
+To handle authentication in non-interactive environments like CI/CD pipelines, configure Git to use the **SSH protocol** instead of HTTPS. This allows for authentication with an SSH key. This command globally configures Git to rewrite any `https://github.com/` URLs to `ssh://git@github.com/`.
+
+    git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+
+**Method 2: Using GitHub CLI**
+
+An alternative to using SSH is to leverage the **GitHub CLI** as a Git credential helper. In this case, Git will still access the repository over HTTPS, but it will use the GitHub CLI to handle the authentication process, eliminating the need to manually enter a password.
+
+    git config --global --add 'credential.https://github.com.helper' '!gh auth git-credential'

--- a/releases/v1.1.5.md
+++ b/releases/v1.1.5.md
@@ -1,0 +1,27 @@
+Grafana **xk6** `v1.1.5` is here! 🎉
+
+This is a maintenance release, with bug fixes and feature enhancements, without new features.
+
+## Building private extensions
+
+Previously, the `build` command did not work correctly with private extensions. This is because the environment variables required for git over SSH were not passed to the build library. This has now been fixed so that git over SSH works, which is crucial for building private extensions.
+
+To build an `xk6` extension from a private Git repository, you need to configure your environment to handle authentication.
+
+**Core Prerequisite**
+
+First, you must set the **`GOPRIVATE`** environment variable. This tells the Go compiler to bypass the standard Go proxy for your repository, allowing it to access the private module directly.
+
+    export GOPRIVATE=github.com/owner/repo
+
+**Method 1: Using SSH**
+
+To handle authentication in non-interactive environments like CI/CD pipelines, configure Git to use the **SSH protocol** instead of HTTPS. This allows for authentication with an SSH key. This command globally configures Git to rewrite any `https://github.com/` URLs to `ssh://git@github.com/`.
+
+    git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+
+**Method 2: Using GitHub CLI**
+
+An alternative to using SSH is to leverage the **GitHub CLI** as a Git credential helper. In this case, Git will still access the repository over HTTPS, but it will use the GitHub CLI to handle the authentication process, eliminating the need to manually enter a password.
+
+    git config --global --add 'credential.https://github.com.helper' '!gh auth git-credential'


### PR DESCRIPTION
Previously, the `build` command did not work correctly with private extensions. This is because the environment variables required for git over SSH were not passed to the build library. This has now been fixed so that git over SSH works, which is crucial for building private extensions.
