### PR TITLE
License validation aligned with Grafana Plugins policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,26 @@ xk6 lint analyzes the source of the k6 extension and try to build k6 with the ex
 
 The contents of the source directory are used for analysis. If the directory is a git workdir, it also analyzes the git metadata. The analysis is completely local and does not use external APIs (e.g. repository manager API) or services.
 
+Compliance with the requirements expected of k6 extensions is checked by various compliance checkers.
+
+- `module` - checks if there is a valid `go.mod`
+- `replace` - checks if there is no `replace` directive in `go.mod`
+- `readme` - checks if there is a readme file
+- `examples` - checks if there are files in the `examples` directory
+- `license` - checks whether there is an acceptable license
+  - `AGPL-3.0`
+  - `Apache-2.0`
+  - `BSD`
+  - `GPL-3.0`
+  - `LGPL-3.0`
+  - `MIT`
+- `git` - checks if the directory is git workdir
+- `versions` - checks for semantic versioning git tags
+- `build` - checks if the latest k6 version can be built with the extension
+- `smoke` - checks if the smoke test script exists and runs successfully (`smoke.js`, `smoke.ts`, `smoke.test.js` or `smoke.test.ts` in the `test`,`tests`, `examples` or the base directory)
+- `types` - checks if the TypeScript API declaration file exists (`index.d.ts` in the `docs`, `api-docs` or the base directory)
+- `codeowners` - checks if there is a CODEOWNERS file (for official extensions) (in the `.github` or `docs` or in the base directory)
+
 The result of the analysis is compliance expressed as a percentage (`0`-`100`). This value is created as a weighted, normalized value of the scores of each checker. A compliance grade is created from the percentage value (`A`-`F`).
 
 By default, text output is generated. The `--json` flag can be used to generate the result in JSON format.

--- a/internal/cmd/help/lint.md
+++ b/internal/cmd/help/lint.md
@@ -6,6 +6,26 @@ xk6 lint analyzes the source of the k6 extension and try to build k6 with the ex
 
 The contents of the source directory are used for analysis. If the directory is a git workdir, it also analyzes the git metadata. The analysis is completely local and does not use external APIs (e.g. repository manager API) or services.
 
+Compliance with the requirements expected of k6 extensions is checked by various compliance checkers.
+
+- `module` - checks if there is a valid `go.mod`
+- `replace` - checks if there is no `replace` directive in `go.mod`
+- `readme` - checks if there is a readme file
+- `examples` - checks if there are files in the `examples` directory
+- `license` - checks whether there is an acceptable license
+  - `AGPL-3.0`
+  - `Apache-2.0`
+  - `BSD`
+  - `GPL-3.0`
+  - `LGPL-3.0`
+  - `MIT`
+- `git` - checks if the directory is git workdir
+- `versions` - checks for semantic versioning git tags
+- `build` - checks if the latest k6 version can be built with the extension
+- `smoke` - checks if the smoke test script exists and runs successfully (`smoke.js`, `smoke.ts`, `smoke.test.js` or `smoke.test.ts` in the `test`,`tests`, `examples` or the base directory)
+- `types` - checks if the TypeScript API declaration file exists (`index.d.ts` in the `docs`, `api-docs` or the base directory)
+- `codeowners` - checks if there is a CODEOWNERS file (for official extensions) (in the `.github` or `docs` or in the base directory)
+
 The result of the analysis is compliance expressed as a percentage (`0`-`100`). This value is created as a weighted, normalized value of the scores of each checker. A compliance grade is created from the percentage value (`A`-`F`).
 
 By default, text output is generated. The `--json` flag can be used to generate the result in JSON format.

--- a/internal/lint/checker_license.go
+++ b/internal/lint/checker_license.go
@@ -28,78 +28,28 @@ func checkerLicense(_ context.Context, dir string) *checkResult {
 		}
 	}
 
-	return checkFailed("no valid license found")
+	return checkFailed("no accepted license found")
 }
 
-// source: https://spdx.org/licenses/
-// both FSF Free and OSI Approved licenses.
+// source: https://grafana.com/legal/plugins/#accepted-licenses
 var validLicenses = map[string]struct{}{ //nolint:gochecknoglobals
-	"AFL-1.1":           {},
-	"AFL-1.2":           {},
-	"AFL-2.0":           {},
-	"AFL-2.1":           {},
-	"AFL-3.0":           {},
+	// AGPL-3.0
 	"AGPL-3.0":          {},
 	"AGPL-3.0-only":     {},
 	"AGPL-3.0-or-later": {},
-	"Apache-1.1":        {},
-	"Apache-2.0":        {},
-	"APSL-2.0":          {},
-	"Artistic-2.0":      {},
-	"BSD-2-Clause":      {},
-	"BSD-3-Clause":      {},
-	"BSL-1.0":           {},
-	"CDDL-1.0":          {},
-	"CPAL-1.0":          {},
-	"CPL-1.0":           {},
-	"ECL-2.0":           {},
-	"EFL-2.0":           {},
-	"EPL-1.0":           {},
-	"EPL-2.0":           {},
-	"EUDatagrid":        {},
-	"EUPL-1.1":          {},
-	"EUPL-1.2":          {},
-	"GPL-2.0-only":      {},
-	"GPL-2.0":           {},
-	"GPL-2.0-or-later":  {},
-	"GPL-3.0-only":      {},
-	"GPL-3.0":           {},
-	"GPL-3.0-or-later":  {},
-	"HPND":              {},
-	"Intel":             {},
-	"IPA":               {},
-	"IPL-1.0":           {},
-	"ISC":               {},
-	"LGPL-2.1":          {},
-	"LGPL-2.1-only":     {},
-	"LGPL-2.1-or-later": {},
+	// Apache-2.0
+	"Apache-2.0": {},
+	// BSD
+	"BSD-2-Clause": {},
+	"BSD-3-Clause": {},
+	// GPL-3.0
+	"GPL-3.0-only":     {},
+	"GPL-3.0":          {},
+	"GPL-3.0-or-later": {},
+	// LGPL-3.0
 	"LGPL-3.0":          {},
 	"LGPL-3.0-only":     {},
 	"LGPL-3.0-or-later": {},
-	"LPL-1.02":          {},
-	"MIT":               {},
-	"MPL-1.1":           {},
-	"MPL-2.0":           {},
-	"MS-PL":             {},
-	"MS-RL":             {},
-	"NCSA":              {},
-	"Nokia":             {},
-	"OFL-1.1":           {},
-	"OSL-1.0":           {},
-	"OSL-2.0":           {},
-	"OSL-2.1":           {},
-	"OSL-3.0":           {},
-	"PHP-3.01":          {},
-	"Python-2.0":        {},
-	"QPL-1.0":           {},
-	"RPSL-1.0":          {},
-	"SISSL":             {},
-	"Sleepycat":         {},
-	"SPL-1.0":           {},
-	"Unlicense":         {},
-	"UPL-1.0":           {},
-	"W3C":               {},
-	"Zlib":              {},
-	"ZPL-2.0":           {},
-	"ZPL-2.1":           {},
+	// MIT
+	"MIT": {},
 }

--- a/releases/v1.1.5.md
+++ b/releases/v1.1.5.md
@@ -2,6 +2,10 @@ Grafana **xk6** `v1.1.5` is here! 🎉
 
 This is a maintenance release, with bug fixes and feature enhancements, without new features.
 
+Changes:
+ - [Building private extensions](#building-private-extensions)
+ - [License Validation Aligned with Grafana Plugins Policy](#license-validation-aligned-with-grafana-plugins-policy)
+
 ## Building private extensions
 
 Previously, the `build` command did not work correctly with private extensions. This is because the environment variables required for git over SSH were not passed to the build library. This has now been fixed so that git over SSH works, which is crucial for building private extensions.
@@ -25,3 +29,10 @@ To handle authentication in non-interactive environments like CI/CD pipelines, c
 An alternative to using SSH is to leverage the **GitHub CLI** as a Git credential helper. In this case, Git will still access the repository over HTTPS, but it will use the GitHub CLI to handle the authentication process, eliminating the need to manually enter a password.
 
     git config --global --add 'credential.https://github.com.helper' '!gh auth git-credential'
+
+### License Validation Aligned with Grafana Plugins Policy
+
+The `xk6 lint` command's license checker has been updated to align with the official Grafana Plugins policy. Previously, the checker accepted a broad range of OSI-approved licenses, which was wider than the list of licenses accepted by Grafana.
+
+With this release, `xk6 lint` now validates extension licenses against the specific list found in the **Accepted licenses** section of the [Grafana Plugins policy](https://grafana.com/legal/plugins/#accepted-licenses). This change ensures that extensions passing the `license` check are compatible with Grafana Cloud's license requirements.
+


### PR DESCRIPTION
The `xk6 lint` command's license checker has been updated to align with the official Grafana Plugins policy. Previously, the checker accepted a broad range of OSI-approved licenses, which was wider than the list of licenses accepted by Grafana.

With this release, `xk6 lint` now validates extension licenses against the specific list found in the **Accepted licenses** section of the [Grafana Plugins policy](https://grafana.com/legal/plugins/#accepted-licenses). This change ensures that extensions passing the `license` check are compatible with Grafana Cloud's license requirements.
