### PR TITLE
Added gosec and govulncheck to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 ARG GO_VERSION=1.24.7
 ARG VARIANT=alpine3.22
+ARG GOSEC_VERSION=2.22.8
+
+FROM securego/gosec:${GOSEC_VERSION} AS gosec
+
 FROM golang:${GO_VERSION}-${VARIANT} AS builder
+
+RUN apk update && apk add git
 
 WORKDIR /build
 
@@ -8,8 +14,9 @@ COPY . .
 
 ARG GOFLAGS="-ldflags=-w -ldflags=-s"
 
-RUN CGO_ENABLED=0 go build -o /xk6 -trimpath .
-RUN CGO_ENABLED=0 go build -o /fixids -trimpath ./internal/fixids
+RUN CGO_ENABLED=0 go build -o xk6 -trimpath .
+RUN CGO_ENABLED=0 go build -o fixids -trimpath ./internal/fixids
+RUN GOBIN=/build go install -ldflags="-s -w" golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
 FROM golang:${GO_VERSION}-${VARIANT}
 
@@ -17,8 +24,10 @@ RUN apk update && apk add git && \
     addgroup --gid 1000 xk6 && \
     adduser --uid 1000 --ingroup xk6 --disabled-password --gecos "" xk6
 
-COPY --from=builder --chown=root:root --chmod=4755 fixids /usr/local/bin/
-COPY --from=builder --chown=xk6:xk6 --chmod=755 xk6 /usr/local/bin/
+COPY --from=gosec /bin/gosec /usr/local/bin/
+COPY --from=builder --chown=root:root --chmod=755 /build/govulncheck /usr/local/bin/
+COPY --from=builder --chown=root:root --chmod=4755 /build/fixids /usr/local/bin/
+COPY --from=builder --chown=xk6:xk6 --chmod=755 /build/xk6 /usr/local/bin/
 COPY --chown=root:root --chmod=755 docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 
 WORKDIR /xk6

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,16 @@
 ARG GO_VERSION=1.24.7
 ARG VARIANT=alpine3.22
+ARG GOSEC_VERSION=2.22.8
+
+FROM securego/gosec:${GOSEC_VERSION} AS gosec
+
+FROM golang:${GO_VERSION}-${VARIANT} AS builder
+
+RUN apk update && apk add git
+
+WORKDIR /build
+
+RUN GOBIN=/build go install -ldflags="-s -w" golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
 FROM golang:${GO_VERSION}-${VARIANT}
 
@@ -7,6 +18,8 @@ RUN apk update && apk add git && \
     addgroup --gid 1000 xk6 && \
     adduser --uid 1000 --ingroup xk6 --disabled-password --gecos "" xk6
 
+COPY --from=gosec /bin/gosec /usr/local/bin/gosec
+COPY --from=builder --chown=root:root --chmod=755 /build/govulncheck /usr/local/bin/
 COPY --chown=root:root --chmod=4755 fixids /usr/local/bin/
 COPY --chown=xk6:xk6 --chmod=755 xk6 /usr/local/bin/
 COPY --chown=root:root --chmod=755 docker-entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/releases/v1.1.5.md
+++ b/releases/v1.1.5.md
@@ -1,10 +1,11 @@
 Grafana **xk6** `v1.1.5` is here! 🎉
 
-This is a maintenance release, with bug fixes and feature enhancements, without new features.
+This is a maintenance release, with bug fixes and feature enhancements.
 
 Changes:
  - [Building private extensions](#building-private-extensions)
  - [License Validation Aligned with Grafana Plugins Policy](#license-validation-aligned-with-grafana-plugins-policy)
+ - [The lint command is now functional in Docker images](#the-lint-command-is-now-functional-in-docker-images)
 
 ## Building private extensions
 
@@ -36,3 +37,8 @@ The `xk6 lint` command's license checker has been updated to align with the offi
 
 With this release, `xk6 lint` now validates extension licenses against the specific list found in the **Accepted licenses** section of the [Grafana Plugins policy](https://grafana.com/legal/plugins/#accepted-licenses). This change ensures that extensions passing the `license` check are compatible with Grafana Cloud's license requirements.
 
+### The lint command is now functional in Docker images
+
+The official `xk6` Docker image now includes the `gosec` and `govulncheck` tools. Previously, these tools were missing from the image, preventing the `xk6 lint` command from performing security and vulnerability checks.
+
+With this update, the `xk6 lint` command can be used to its full extent within the Docker container, which supports automated and containerized workflows.


### PR DESCRIPTION
The official `xk6` Docker image now includes the `gosec` and `govulncheck` tools. Previously, these tools were missing from the image, preventing the `xk6 lint` command from performing security and vulnerability checks.

With this update, the `xk6 lint` command can be used to its full extent within the Docker container, which supports automated and containerized workflows.