### PR TITLE
Release v1.2.5

### DIFF
--- a/releases/v1.2.5.md
+++ b/releases/v1.2.5.md
@@ -1,0 +1,11 @@
+Grafana **xk6** `v1.2.5` is here! 🎉
+
+This patch release includes automated dependency updates managed by Renovate, demonstrating the automated dependency management system introduced in v1.2.4.
+
+## Dependency Updates
+
+* Bumps **`golang`** base image from `1.25.3-alpine3.22` to `1.25.4-alpine3.22` (#350)
+* Bumps **`golangci/golangci-lint-action`** from v8 to v9 (major version update) (#352)
+* Bumps **`docker/setup-qemu-action`** from `v3.6.0` to `v3.7.0` (#349)
+* Updates **workflow tooling** including `golangci-lint` and `goreleaser` in workflows and devcontainer (#351)
+


### PR DESCRIPTION
Grafana **xk6** `v1.2.5` is here! 🎉

This patch release includes automated dependency updates managed by Renovate, demonstrating the automated dependency management system introduced in v1.2.4.

## Dependency Updates

* Bumps **`golang`** base image from `1.25.3-alpine3.22` to `1.25.4-alpine3.22` (#350)
* Bumps **`golangci/golangci-lint-action`** from v8 to v9 (major version update) (#352)
* Bumps **`docker/setup-qemu-action`** from `v3.6.0` to `v3.7.0` (#349)
* Updates **workflow tooling** including `golangci-lint` and `goreleaser` in workflows and devcontainer (#351)