### PR TITLE
Fix workflow integration test condition

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -217,7 +217,7 @@ jobs:
           xk6 build -v --with ${MODULE_PATH}@${VERSION} ${WITH}
 
       - name: Integration Test
-        if: ${{ env.bats != '' && runner.os == 'Linux' }}
+        if: ${{ inputs.bats != '' && runner.os == 'Linux' }}
         env:
           K6_VERSION: ${{ inputs.k6-version }}
           K6: ${{env.DIST_DIR}}/k6

--- a/.github/workflows/tooling-release.yml
+++ b/.github/workflows/tooling-release.yml
@@ -139,7 +139,7 @@ jobs:
           args: release --clean --snapshot
 
       - name: Integration Test
-        if: ${{ env.bats != '' }}
+        if: ${{ inputs.bats != '' }}
         env:
           K6_VERSIONS: ${{ join(fromJSON(inputs.k6-versions),' ') }}
           BATS: ${{ inputs.bats }}


### PR DESCRIPTION
## Problem

The conditional execution of integration tests in workflow files was using the wrong condition, testing `env.bats` instead of `inputs.bats`. This caused the "Setup Bats" and "Integration Test" steps to evaluate an undefined environment variable rather than the workflow input parameter.

## Changes

Updated the condition in two workflow files:
- `.github/workflows/tooling-release.yml`
- `.github/workflows/extension-release.yml`

Changed from:
```yaml
if: ${{ env.bats != '' && runner.os == 'Linux' }}
```

To:
```yaml
if: ${{ inputs.bats != '' && runner.os == 'Linux' }}
```