### PR TITLE
Update setup-xk6 action to v1.1.1 in workflows

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -198,7 +198,7 @@ jobs:
           file-install: false
 
       - name: Setup xk6 ${{ inputs.xk6-version }}
-        uses: grafana/setup-xk6@92356c2715efc0f13876e324b2b05d8ea26c4e59 # v1.1.0
+        uses: grafana/setup-xk6@97b842b765bd3fea56db7195e98c5f61cab8fe46 # v1.1.1
         with:
           xk6-version: ${{ inputs.xk6-version }}
 

--- a/.github/workflows/extension-validate.yml
+++ b/.github/workflows/extension-validate.yml
@@ -194,7 +194,7 @@ jobs:
           go-version: ${{inputs.go-version}}
 
       - name: Setup xk6 ${{ inputs.xk6-version }}
-        uses: grafana/setup-xk6@92356c2715efc0f13876e324b2b05d8ea26c4e59 # v1.1.0
+        uses: grafana/setup-xk6@97b842b765bd3fea56db7195e98c5f61cab8fe46 # v1.1.1
         with:
           xk6-version: ${{ inputs.xk6-version }}
 
@@ -335,7 +335,7 @@ jobs:
 
 
       - name: Setup xk6 ${{ inputs.xk6-version }}
-        uses: grafana/setup-xk6@92356c2715efc0f13876e324b2b05d8ea26c4e59 # v1.1.0
+        uses: grafana/setup-xk6@97b842b765bd3fea56db7195e98c5f61cab8fe46 # v1.1.1
         with:
           xk6-version: ${{ inputs.xk6-version }}
 


### PR DESCRIPTION
In setup-xk6 `v1.1.0` release `~` character is not resolved in `dir` input parameter. This is fixed in `v1.1.1`.
