### PR TITLE
Fix missing permission for liveness workflow call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     name: Liveness
     needs: ["release"]
     uses: ./.github/workflows/liveness.yml
+    permissions:
+      contents: read
     with:
       xk6-version: "${{github.ref_name}}"
       xk6-it-version: "submodule"


### PR DESCRIPTION
The release workflow was missing read permission in the liveness workflow call. This has been fixed.