### PR TITLE
Prepare v1.3.3 release

### DIFF
--- a/releases/v1.3.3.md
+++ b/releases/v1.3.3.md
@@ -1,0 +1,24 @@
+Grafana **xk6** `v1.3.3` is here! 🎉
+
+This is a patch release that addresses security vulnerabilities in dependencies and updates the Docker base image.
+
+## Security
+
+- Update gosec to v2.22.11 ([#403](https://github.com/grafana/xk6/pull/403))
+
+## Dependencies
+
+- Update golang.org/x/mod to v0.32.0 ([#407](https://github.com/grafana/xk6/pull/407))
+
+## Docker
+
+- Update Go version to 1.25.5-alpine3.23 in Dockerfiles ([#411](https://github.com/grafana/xk6/pull/411))
+
+## Maintenance
+
+- Update GitHub Actions workflows:
+  - Update actions/setup-go digest ([#409](https://github.com/grafana/xk6/pull/409))
+  - Update GitHub artifact actions to v4 ([#406](https://github.com/grafana/xk6/pull/406))
+  - Update oven-sh/setup-bun action to v2.1.0 ([#405](https://github.com/grafana/xk6/pull/405))
+  - Update grafana/shared-workflows/dockerhub-login action to v1.0.3 ([#404](https://github.com/grafana/xk6/pull/404))
+  - Update workflow tooling ([#408](https://github.com/grafana/xk6/pull/408))


### PR DESCRIPTION
This PR adds release notes for v1.3.3 patch release.

## Summary
This patch release addresses security vulnerabilities in dependencies and updates the Docker base image.

### Key changes:
- Security: Update gosec to v2.22.11
- Dependencies: Update golang.org/x/mod to v0.32.0
- Docker: Update Go version to 1.25.5-alpine3.23
- Workflows: Update GitHub Actions

Closes #412