### PR TITLE
Prepare v1.3.4 release

### DIFF
--- a/releases/v1.3.4.md
+++ b/releases/v1.3.4.md
@@ -1,0 +1,17 @@
+Grafana **xk6** `v1.3.4` is here! 🎉
+
+This is a patch release that addresses a critical security vulnerability.
+
+## Security
+
+- Fix CVE-2025-15467 vulnerability
+
+## Docker
+
+- Update Go version to 1.25.6-alpine3.23 in Dockerfiles ([#415](https://github.com/grafana/xk6/pull/415))
+
+## Maintenance
+
+- Update GitHub Actions workflows:
+  - Update docker/login-action action to v3.7.0 ([#418](https://github.com/grafana/xk6/pull/418))
+  - Update oven-sh/setup-bun action to v2.1.2 ([#414](https://github.com/grafana/xk6/pull/414))


### PR DESCRIPTION
This release addresses CVE-2025-15467 and includes dependency updates.

## Changes
- Add release notes for v1.3.4
- Security fix for CVE-2025-15467
- Update Go version to 1.25.6-alpine3.23 in Dockerfiles
- Update GitHub Actions dependencies