### PR TITLE
Fix: append .exe extension to default output filename on Windows

### DIFF
--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.k6.io/xk6/internal/sync"
@@ -38,6 +39,9 @@ func buildCmd() *cobra.Command {
 			}
 
 			opts.outputChanged = cmd.Flags().Lookup("output").Changed
+			if !opts.outputChanged && opts.os == "windows" && !strings.HasSuffix(opts.output, ".exe") {
+				opts.output += ".exe"
+			}
 
 			return buildRunE(cmd.Context(), opts)
 		},


### PR DESCRIPTION
**Clarification**: This issue specifically occurs when **cross-compiling to Windows** from another platform (e.g., Linux or macOS). When compiling directly on Windows, Go already appends the .exe extension to the default output name automatically.

The fix ensures that the .exe extension is also added when cross-compiling to Windows (GOOS=windows) from other platforms.

Fixes #427