### PR TITLE
feat: auto-resolve major version for custom k6 repo forks

### DIFF
--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -86,7 +86,7 @@ func buildRunE(ctx context.Context, stdout io.Writer, opts *buildOptions) error 
 		slog.Info("A new binary has been built based on k6", "version", k6ver)
 	}
 
-	k6latest, err := sync.GetLatestK6VersionFor(ctx, k6modPath)
+	k6latest, err := sync.GetLatestVersion(ctx, k6modPath)
 	if err == nil && k6ver != k6latest {
 		slog.Warn("Newer k6 version available", "actual", k6ver, "latest", k6latest)
 	} else if err != nil {

--- a/internal/cmd/build_helper.go
+++ b/internal/cmd/build_helper.go
@@ -12,8 +12,8 @@ import (
 	"github.com/grafana/k6foundry"
 	"github.com/spf13/pflag"
 	"github.com/szkiba/efa"
-	"golang.org/x/mod/module"
 	"go.k6.io/xk6/internal/sync"
+	"golang.org/x/mod/module"
 )
 
 type buildOptions struct {
@@ -360,4 +360,3 @@ func (m *modules) Type() string {
 
 	return "module[@version][=replacement]"
 }
-

--- a/internal/cmd/build_helper.go
+++ b/internal/cmd/build_helper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/k6foundry"
 	"github.com/spf13/pflag"
 	"github.com/szkiba/efa"
+	"golang.org/x/mod/module"
 	"go.k6.io/xk6/internal/sync"
 )
 
@@ -178,8 +179,8 @@ func newFoundry(ctx context.Context, opts *buildOptions) (k6foundry.Foundry, err
 		fopts.K6MajorVersion = opts.k6repo[len(defaultK6Repo+"/"):]
 	} else if opts.k6repo != defaultK6Repo {
 		fopts.K6Repo = opts.k6repo
-		if maj := majorVersionSuffix(opts.k6repo); maj != "" {
-			fopts.K6MajorVersion = maj
+		if _, pathMajor, ok := module.SplitPathVersion(opts.k6repo); ok && pathMajor != "" {
+			fopts.K6MajorVersion = module.PathMajorPrefix(pathMajor)
 		}
 	}
 
@@ -283,7 +284,7 @@ func (m *modules) Set(val string) error {
 // inspected first so their declared k6 version drives the build.
 func resolveK6Repo(ctx context.Context, opts *buildOptions) {
 	// User already included a /vN suffix — trust it as-is.
-	if majorVersionSuffix(opts.k6repo) != "" {
+	if _, pathMajor, ok := module.SplitPathVersion(opts.k6repo); ok && pathMajor != "" {
 		slog.Debug("Using k6 repo with explicit major version suffix", "repo", opts.k6repo)
 		return
 	}
@@ -360,24 +361,3 @@ func (m *modules) Type() string {
 	return "module[@version][=replacement]"
 }
 
-// majorVersionSuffix returns the /vN suffix of a module path (e.g. "v2" for
-// "github.com/foo/bar/v2"), or "" if none is present.
-func majorVersionSuffix(path string) string {
-	idx := strings.LastIndex(path, "/")
-	if idx < 0 {
-		return ""
-	}
-
-	last := path[idx+1:]
-	if len(last) < 2 || last[0] != 'v' {
-		return ""
-	}
-
-	for _, c := range last[1:] {
-		if c < '0' || c > '9' {
-			return ""
-		}
-	}
-
-	return last
-}

--- a/internal/cmd/build_helper.go
+++ b/internal/cmd/build_helper.go
@@ -172,11 +172,15 @@ func newFoundry(ctx context.Context, opts *buildOptions) (k6foundry.Foundry, err
 
 	// If k6repo is a versioned k6 module path (e.g. go.k6.io/k6/v2), extract the major
 	// version so k6foundry can resolve the correct module path for non-semver versions
-	// such as "latest". For actual forks (e.g. github.com/myfork/k6), set K6Repo instead.
+	// such as "latest". For actual forks (e.g. github.com/myfork/k6/v2), set K6Repo and
+	// extract K6MajorVersion from the /vN suffix so the require path matches.
 	if strings.HasPrefix(opts.k6repo, defaultK6Repo+"/v") {
 		fopts.K6MajorVersion = opts.k6repo[len(defaultK6Repo+"/"):]
 	} else if opts.k6repo != defaultK6Repo {
 		fopts.K6Repo = opts.k6repo
+		if maj := majorVersionSuffix(opts.k6repo); maj != "" {
+			fopts.K6MajorVersion = maj
+		}
 	}
 
 	if logger.Enabled(ctx, slog.LevelDebug) {
@@ -274,26 +278,45 @@ func (m *modules) Set(val string) error {
 }
 
 // resolveK6Repo sets opts.k6repo (and opts.k6version when appropriate) to the
-// correct k6 module path when the user has not overridden --k6-repo. This
-// ensures that v2+ releases are used without requiring an explicit flag.
+// correct versioned module path, appending the /vN suffix when needed.
+// For the default repo with no explicit version, extension dependencies are
+// inspected first so their declared k6 version drives the build.
 func resolveK6Repo(ctx context.Context, opts *buildOptions) {
-	if opts.k6repo != defaultK6Repo {
-		slog.Debug("Using explicit k6 repo, skipping auto-resolution", "repo", opts.k6repo)
+	// User already included a /vN suffix — trust it as-is.
+	if majorVersionSuffix(opts.k6repo) != "" {
+		slog.Debug("Using k6 repo with explicit major version suffix", "repo", opts.k6repo)
 		return
 	}
 
 	if opts.k6version == defaultK6Version {
-		slog.Debug("Resolving k6 module from extension dependencies (version: latest)")
+		// For the default repo, inspect extension dependencies first so their
+		// declared k6 version drives the build; fall back to overall latest.
+		if opts.k6repo == defaultK6Repo {
+			slog.Debug("Resolving k6 module from extension dependencies (version: latest)")
 
-		// No explicit version: inspect extension dependencies first, then
-		// fall back to the overall latest across all major versions.
-		path, version, err := sync.ResolveK6ModuleForExtensions(ctx, extensionModules(opts))
-		if err != nil {
-			slog.Warn("Failed to resolve k6 module from extensions, using default", "error", err)
+			path, version, err := sync.ResolveK6ModuleForExtensions(ctx, extensionModules(opts))
+			if err != nil {
+				slog.Warn("Failed to resolve k6 module from extensions, using default", "error", err)
+				return
+			}
+
+			slog.Debug("Resolved k6 module", "repo", path, "version", version)
+
+			opts.k6repo = path
+			opts.k6version = version
+
 			return
 		}
 
-		slog.Debug("Resolved k6 module", "repo", path, "version", version)
+		slog.Debug("Resolving latest version for k6 repo", "repo", opts.k6repo)
+
+		path, version, err := sync.GetOverallLatestVersionFor(ctx, opts.k6repo)
+		if err != nil {
+			slog.Warn("Failed to resolve k6 repo latest version, using as-is", "repo", opts.k6repo, "error", err)
+			return
+		}
+
+		slog.Debug("Resolved k6 repo", "repo", path, "version", version)
 
 		opts.k6repo = path
 		opts.k6version = version
@@ -301,17 +324,17 @@ func resolveK6Repo(ctx context.Context, opts *buildOptions) {
 		return
 	}
 
-	slog.Debug("Resolving k6 module path for explicit version", "version", opts.k6version)
+	// Explicit version (semver, SHA, branch): detect the versioned module path
+	// so that e.g. a v2 SHA resolves to the /v2 path for any repo.
+	slog.Debug("Resolving k6 repo module path for version", "repo", opts.k6repo, "version", opts.k6version)
 
-	// Explicit version (semver, SHA, branch name): detect the module path from
-	// the version itself so that e.g. a v2 SHA resolves to go.k6.io/k6/v2.
-	path, err := sync.ResolveK6ModuleForVersion(ctx, opts.k6version)
+	path, err := sync.ResolveModuleForVersion(ctx, opts.k6repo, opts.k6version)
 	if err != nil {
-		slog.Warn("Failed to resolve k6 module for version, using default", "error", err)
+		slog.Warn("Failed to resolve k6 repo module path, using as-is", "repo", opts.k6repo, "error", err)
 		return
 	}
 
-	slog.Debug("Resolved k6 module path", "repo", path, "version", opts.k6version)
+	slog.Debug("Resolved k6 repo path", "repo", path)
 
 	opts.k6repo = path
 }
@@ -335,4 +358,26 @@ func (m *modules) Type() string {
 	}
 
 	return "module[@version][=replacement]"
+}
+
+// majorVersionSuffix returns the /vN suffix of a module path (e.g. "v2" for
+// "github.com/foo/bar/v2"), or "" if none is present.
+func majorVersionSuffix(path string) string {
+	idx := strings.LastIndex(path, "/")
+	if idx < 0 {
+		return ""
+	}
+
+	last := path[idx+1:]
+	if len(last) < 2 || last[0] != 'v' {
+		return ""
+	}
+
+	for _, c := range last[1:] {
+		if c < '0' || c > '9' {
+			return ""
+		}
+	}
+
+	return last
 }

--- a/internal/cmd/build_helper_test.go
+++ b/internal/cmd/build_helper_test.go
@@ -7,31 +7,6 @@ import (
 	"testing"
 )
 
-func TestMajorVersionSuffix(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		path string
-		want string
-	}{
-		{"github.com/foo/bar/v2", "v2"},
-		{"github.com/foo/bar/v10", "v10"},
-		{"github.com/foo/bar", ""},
-		{"github.com/foo/v2/bar", ""},  // v2 not at end
-		{"github.com/foo/bar/v2x", ""}, // non-digit after v2
-		{"github.com/foo/bar/v", ""},   // just "v" with no digits
-		{"go.k6.io/k6/v2", "v2"},
-		{"go.k6.io/k6", ""},
-	}
-
-	for _, tc := range cases {
-		got := majorVersionSuffix(tc.path)
-		if got != tc.want {
-			t.Errorf("majorVersionSuffix(%q) = %q, want %q", tc.path, got, tc.want)
-		}
-	}
-}
-
 func TestResolveK6Repo_CustomV2SHA(t *testing.T) {
 	const base = "github.com/myfork/k6"
 	const sha = "f520efb45f42"

--- a/internal/cmd/build_helper_test.go
+++ b/internal/cmd/build_helper_test.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMajorVersionSuffix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"github.com/foo/bar/v2", "v2"},
+		{"github.com/foo/bar/v10", "v10"},
+		{"github.com/foo/bar", ""},
+		{"github.com/foo/v2/bar", ""},    // v2 not at end
+		{"github.com/foo/bar/v2x", ""},   // non-digit after v2
+		{"github.com/foo/bar/v", ""},     // just "v" with no digits
+		{"go.k6.io/k6/v2", "v2"},
+		{"go.k6.io/k6", ""},
+	}
+
+	for _, tc := range cases {
+		got := majorVersionSuffix(tc.path)
+		if got != tc.want {
+			t.Errorf("majorVersionSuffix(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestResolveK6Repo_CustomV2SHA(t *testing.T) {
+	const base = "github.com/myfork/k6"
+	const sha = "f520efb45f42"
+	const pseudo = "v2.0.1-0.20260401000000-f520efb45f42"
+
+	basev2 := base + "/v2"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case fmt.Sprintf("/%s/@v/%s.info", basev2, sha):
+			_, _ = fmt.Fprintf(w, `{"Version":%q,"Time":"2026-04-01T00:00:00Z"}`, pseudo)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("GOPROXY", srv.URL)
+
+	opts := &buildOptions{
+		extensions:   new(modules),
+		replacements: &modules{replace: true},
+		k6repo:       base,
+		k6version:    sha,
+	}
+
+	resolveK6Repo(t.Context(), opts)
+
+	if opts.k6repo != basev2 {
+		t.Errorf("expected k6repo %s, got %s", basev2, opts.k6repo)
+	}
+}
+
+func TestResolveK6Repo_CustomV1SHA(t *testing.T) {
+	const base = "github.com/myfork/k6"
+	const sha = "aabbccddeeff"
+	const pseudo = "v0.55.0-0.20260401000000-aabbccddeeff"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case fmt.Sprintf("/%s/@v/%s.info", base, sha):
+			_, _ = fmt.Fprintf(w, `{"Version":%q,"Time":"2026-04-01T00:00:00Z"}`, pseudo)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("GOPROXY", srv.URL)
+
+	opts := &buildOptions{
+		extensions:   new(modules),
+		replacements: &modules{replace: true},
+		k6repo:       base,
+		k6version:    sha,
+	}
+
+	resolveK6Repo(t.Context(), opts)
+
+	if opts.k6repo != base {
+		t.Errorf("expected k6repo %s (unchanged), got %s", base, opts.k6repo)
+	}
+}
+
+func TestResolveK6Repo_ExplicitV2SuffixSkipsProbe(t *testing.T) {
+	// When the repo already has /v2, resolveK6Repo should not probe.
+	const repo = "github.com/myfork/k6/v2"
+	const sha = "deadbeefcafe"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected proxy request: %s", r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	t.Setenv("GOPROXY", srv.URL)
+
+	opts := &buildOptions{
+		extensions:   new(modules),
+		replacements: &modules{replace: true},
+		k6repo:       repo,
+		k6version:    sha,
+	}
+
+	resolveK6Repo(t.Context(), opts)
+
+	if opts.k6repo != repo {
+		t.Errorf("expected k6repo %s (unchanged), got %s", repo, opts.k6repo)
+	}
+}
+
+func TestResolveK6Repo_CustomLatest(t *testing.T) {
+	const base = "github.com/myfork/k6"
+	basev2 := base + "/v2"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case fmt.Sprintf("/%s/@latest", base):
+			_, _ = fmt.Fprint(w, `{"version":"v0.55.0"}`)
+		case fmt.Sprintf("/%s/@latest", basev2):
+			_, _ = fmt.Fprint(w, `{"version":"v2.1.0"}`)
+		case fmt.Sprintf("/%s/v3/@latest", base):
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("GOPROXY", srv.URL)
+
+	opts := &buildOptions{
+		extensions:   new(modules),
+		replacements: &modules{replace: true},
+		k6repo:       base,
+		k6version:    defaultK6Version,
+	}
+
+	resolveK6Repo(t.Context(), opts)
+
+	if opts.k6repo != basev2 {
+		t.Errorf("expected k6repo %s, got %s", basev2, opts.k6repo)
+	}
+
+	if opts.k6version != "v2.1.0" {
+		t.Errorf("expected k6version v2.1.0, got %s", opts.k6version)
+	}
+}

--- a/internal/cmd/build_helper_test.go
+++ b/internal/cmd/build_helper_test.go
@@ -17,9 +17,9 @@ func TestMajorVersionSuffix(t *testing.T) {
 		{"github.com/foo/bar/v2", "v2"},
 		{"github.com/foo/bar/v10", "v10"},
 		{"github.com/foo/bar", ""},
-		{"github.com/foo/v2/bar", ""},    // v2 not at end
-		{"github.com/foo/bar/v2x", ""},   // non-digit after v2
-		{"github.com/foo/bar/v", ""},     // just "v" with no digits
+		{"github.com/foo/v2/bar", ""},  // v2 not at end
+		{"github.com/foo/bar/v2x", ""}, // non-digit after v2
+		{"github.com/foo/bar/v", ""},   // just "v" with no digits
 		{"go.k6.io/k6/v2", "v2"},
 		{"go.k6.io/k6", ""},
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -109,47 +109,46 @@ func Sync(ctx context.Context, dir string, opts *Options) (*Result, error) {
 	return result, nil
 }
 
-// GetLatestK6VersionFor retrieves the latest version of the given k6 module path from the Go proxy.
-// Use this for k6 major versions beyond v1 (e.g. "go.k6.io/k6/v2").
-func GetLatestK6VersionFor(ctx context.Context, modulePath string) (string, error) {
+// GetLatestVersion retrieves the latest version of the given module path from the Go proxy.
+func GetLatestVersion(ctx context.Context, modulePath string) (string, error) {
 	return getLatestVersion(ctx, modulePath)
 }
 
-// GetOverallLatestK6Version returns the module path and version of the highest
-// published k6 release across all major versions. It starts with go.k6.io/k6
-// and probes go.k6.io/k6/v2, go.k6.io/k6/v3, ... until a major is not found.
-func GetOverallLatestK6Version(ctx context.Context) (modulePath, version string, err error) {
-	return getOverallLatestK6Version(ctx)
+// GetOverallLatestVersionFor returns the module path and version of the highest
+// published release of baseModule across all major versions. It probes baseModule,
+// baseModule/v2, baseModule/v3, … until a major is not found.
+func GetOverallLatestVersionFor(ctx context.Context, baseModule string) (modulePath, version string, err error) {
+	return getOverallLatestVersionFor(ctx, baseModule)
 }
 
-// ResolveK6ModuleForVersion determines the k6 module path for an explicit version
-// string (semver tag, pseudo-version, SHA, or branch name).
+// ResolveModuleForVersion determines the versioned module path for baseModule at
+// the given version string (semver tag, pseudo-version, SHA, or branch name).
 //
 // For clean release tags (e.g. "v2.0.0") the major version is inferred directly.
-// For everything else (SHAs, pseudo-versions, branch names) the Go proxy is
-// queried: the declared module path inside the fetched go.mod is returned, so
-// a SHA that belongs to a v2 commit will correctly yield "go.k6.io/k6/v2".
-func ResolveK6ModuleForVersion(ctx context.Context, version string) (string, error) {
-	// Clean release tags: derive the module path from the major version suffix.
+// For everything else the Go proxy is queried: starting from baseModule it probes
+// baseModule/v2, baseModule/v3, … until the version is found. This allows callers
+// to pass a custom fork base path (e.g. "github.com/myfork/k6") and get back the
+// correctly versioned path (e.g. "github.com/myfork/k6/v2") without having to
+// know the major version in advance.
+func ResolveModuleForVersion(ctx context.Context, baseModule, version string) (string, error) {
 	if semver.IsValid(version) && semver.Prerelease(version) == "" {
-		path := k6ModulePathForSemver(version)
-		slog.Debug("Inferred k6 module path from semver", "version", version, "path", path)
+		major := semver.Major(version)
+
+		var path string
+		if major == "v0" || major == "v1" {
+			path = baseModule
+		} else {
+			path = baseModule + "/" + major
+		}
+
+		slog.Debug("Inferred module path from semver", "base", baseModule, "version", version, "path", path)
 
 		return path, nil
 	}
 
-	slog.Debug("Non-semver version, probing Go proxy to find k6 module path", "version", version)
+	slog.Debug("Non-semver version, probing Go proxy to find module path", "base", baseModule, "version", version)
 
-	return probeK6ModuleForVersion(ctx, version)
-}
-
-func k6ModulePathForSemver(version string) string {
-	major := semver.Major(version) // e.g. "v0", "v1", "v2"
-	if major == "v0" || major == "v1" {
-		return k6BaseModule
-	}
-
-	return k6BaseModule + "/" + major
+	return probeModuleVersionForBase(ctx, baseModule, version)
 }
 
 // versionInfo is the JSON response from the Go proxy /@v/<version>.info endpoint.
@@ -181,13 +180,6 @@ func probeVersionInfo(ctx context.Context, pkg, version string) (string, error) 
 	}
 
 	return info.Version, nil
-}
-
-// probeK6ModuleForVersion asks the Go proxy which k6 major-version module
-// contains the given version string (SHA, branch name, or pseudo-version).
-// It delegates to probeModuleVersionForBase using the k6 base module path.
-func probeK6ModuleForVersion(ctx context.Context, version string) (string, error) {
-	return probeModuleVersionForBase(ctx, k6BaseModule, version)
 }
 
 // probeModuleVersionForBase asks the Go proxy which major-version of the given
@@ -294,7 +286,7 @@ func ResolveK6ModuleForExtensions(
 
 	slog.Debug("No extension declared k6, falling back to overall latest")
 
-	return getOverallLatestK6Version(ctx)
+	return getOverallLatestVersionFor(ctx, k6BaseModule)
 }
 
 func resolveExtensionModfile(ctx context.Context, ext ExtensionModule) (*modfile.File, error) {
@@ -321,16 +313,16 @@ func resolveExtensionModfile(ctx context.Context, ext ExtensionModule) (*modfile
 	return getModule(ctx, ext.Path, ver)
 }
 
-func getOverallLatestK6Version(ctx context.Context) (modulePath, version string, err error) {
-	bestPath := k6BaseModule
-
-	bestVersion, err := getLatestVersion(ctx, k6BaseModule)
+func getOverallLatestVersionFor(ctx context.Context, baseModule string) (modulePath, version string, err error) {
+	bestVersion, err := getLatestVersion(ctx, baseModule)
 	if err != nil {
 		return "", "", err
 	}
 
+	bestPath := baseModule
+
 	for major := 2; ; major++ {
-		modPath := fmt.Sprintf("%s/v%d", k6BaseModule, major)
+		modPath := fmt.Sprintf("%s/v%d", baseModule, major)
 
 		ver, probeErr := getLatestVersion(ctx, modPath)
 		if probeErr != nil {
@@ -374,7 +366,7 @@ func diffRequires(extModfile, k6Modfile *modfile.File) []*Change {
 // and falls back to opts.K6Version if set, or the overall latest version otherwise.
 func resolveK6Module(ctx context.Context, opts *Options, mf *modfile.File) (modulePath, version string, err error) {
 	if len(opts.K6Version) > 0 {
-		path, err := ResolveK6ModuleForVersion(ctx, opts.K6Version)
+		path, err := ResolveModuleForVersion(ctx, k6BaseModule, opts.K6Version)
 		if err != nil {
 			return "", "", err
 		}
@@ -388,7 +380,7 @@ func resolveK6Module(ctx context.Context, opts *Options, mf *modfile.File) (modu
 
 	slog.Info("k6 not found in go.mod, using overall latest version")
 
-	return getOverallLatestK6Version(ctx)
+	return getOverallLatestVersionFor(ctx, k6BaseModule)
 }
 
 // findK6Require finds a k6 module (any major version) in the given modfile.

--- a/internal/sync/sync_internal_test.go
+++ b/internal/sync/sync_internal_test.go
@@ -343,7 +343,7 @@ func TestGetOverallLatestK6Version_OnlyV1(t *testing.T) {
 	defer srv.Close()
 	t.Setenv("GOPROXY", srv.URL)
 
-	path, version, err := getOverallLatestK6Version(t.Context())
+	path, version, err := getOverallLatestVersionFor(t.Context(), k6BaseModule)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -369,7 +369,7 @@ func TestGetOverallLatestK6Version_V2(t *testing.T) {
 	defer srv.Close()
 	t.Setenv("GOPROXY", srv.URL)
 
-	path, version, err := getOverallLatestK6Version(t.Context())
+	path, version, err := getOverallLatestVersionFor(t.Context(), k6BaseModule)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -397,7 +397,7 @@ func TestGetOverallLatestK6Version_MultipleVersions(t *testing.T) {
 	defer srv.Close()
 	t.Setenv("GOPROXY", srv.URL)
 
-	path, version, err := getOverallLatestK6Version(t.Context())
+	path, version, err := getOverallLatestVersionFor(t.Context(), k6BaseModule)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -430,7 +430,7 @@ func TestProbeK6ModuleForVersion_V1SHA(t *testing.T) {
 	defer srv.Close()
 	t.Setenv("GOPROXY", srv.URL)
 
-	path, err := probeK6ModuleForVersion(t.Context(), sha)
+	path, err := probeModuleVersionForBase(t.Context(), k6BaseModule, sha)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -468,7 +468,7 @@ func TestProbeK6ModuleForVersion_V2SHABaseNotFound(t *testing.T) {
 	defer srv.Close()
 	t.Setenv("GOPROXY", srv.URL)
 
-	path, err := probeK6ModuleForVersion(t.Context(), sha)
+	path, err := probeModuleVersionForBase(t.Context(), k6BaseModule, sha)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -528,7 +528,7 @@ func TestProbeK6ModuleForVersion_V3SHASkipsV2(t *testing.T) {
 	defer srv.Close()
 	t.Setenv("GOPROXY", srv.URL)
 
-	path, err := probeK6ModuleForVersion(t.Context(), sha)
+	path, err := probeModuleVersionForBase(t.Context(), k6BaseModule, sha)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -566,13 +566,100 @@ func TestProbeK6ModuleForVersion_V3SHAAbsentV2(t *testing.T) {
 	defer srv.Close()
 	t.Setenv("GOPROXY", srv.URL)
 
-	path, err := probeK6ModuleForVersion(t.Context(), sha)
+	path, err := probeModuleVersionForBase(t.Context(), k6BaseModule, sha)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if path != k6v3 {
 		t.Errorf("expected %s, got %s", k6v3, path)
+	}
+}
+
+func TestResolveModuleForVersion_V1Semver(t *testing.T) {
+	t.Parallel()
+
+	const base = "github.com/myfork/k6"
+
+	path, err := ResolveModuleForVersion(t.Context(), base, "v1.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if path != base {
+		t.Errorf("expected %s, got %s", base, path)
+	}
+}
+
+func TestResolveModuleForVersion_V2Semver(t *testing.T) {
+	t.Parallel()
+
+	const base = "github.com/myfork/k6"
+	const want = base + "/v2"
+
+	path, err := ResolveModuleForVersion(t.Context(), base, "v2.3.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if path != want {
+		t.Errorf("expected %s, got %s", want, path)
+	}
+}
+
+func TestResolveModuleForVersion_V2SHA(t *testing.T) {
+	// Custom fork base module returns 404; v2 has the SHA.
+	const base = "github.com/myfork/k6"
+	const sha = "aabbccdd11223344"
+	const pseudo = "v2.0.1-0.20260401000000-aabbccdd11223344"
+
+	basev2 := base + "/v2"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case fmt.Sprintf("/%s/@v/%s.info", basev2, sha):
+			_, _ = fmt.Fprint(w, modInfo(pseudo))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("GOPROXY", srv.URL)
+
+	path, err := ResolveModuleForVersion(t.Context(), base, sha)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if path != basev2 {
+		t.Errorf("expected %s, got %s", basev2, path)
+	}
+}
+
+func TestResolveModuleForVersion_V1SHA(t *testing.T) {
+	// Custom fork SHA found directly on the base module (v1).
+	const base = "github.com/myfork/k6"
+	const sha = "112233445566"
+	const pseudo = "v0.55.1-0.20260401000000-112233445566"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case fmt.Sprintf("/%s/@v/%s.info", base, sha):
+			_, _ = fmt.Fprint(w, modInfo(pseudo))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("GOPROXY", srv.URL)
+
+	path, err := ResolveModuleForVersion(t.Context(), base, sha)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if path != base {
+		t.Errorf("expected %s, got %s", base, path)
 	}
 }
 
@@ -587,7 +674,7 @@ func TestProbeK6ModuleForVersion_UnknownSHA(t *testing.T) {
 	defer srv.Close()
 	t.Setenv("GOPROXY", srv.URL)
 
-	_, err := probeK6ModuleForVersion(t.Context(), sha)
+	_, err := probeModuleVersionForBase(t.Context(), k6BaseModule, sha)
 	if err == nil {
 		t.Fatal("expected error for unknown SHA, got nil")
 	}


### PR DESCRIPTION
## Summary

When `XK6_K6_REPO` points to a v2+ fork (e.g. `github.com/myfork/k6`), xk6 now probes the Go proxy to detect the correct versioned module path and appends the `/vN` suffix automatically — both the `require` directive (`go.k6.io/k6/v2`) and the `replace` path (`github.com/myfork/k6/v2`) are set consistently. An explicit `/vN` suffix in `XK6_K6_REPO` is trusted as-is, no probing occurs.

## How it works

Resolution follows the same strategy as the default-repo auto-detection introduced in #445, now extended to custom forks:

**Explicit `/vN` suffix:** Trusted as-is, no proxy calls.

**Explicit version (semver, SHA, branch):** `ResolveModuleForVersion` probes the Go proxy starting from the base path, iterating `/v2`, `/v3`, … until the commit is found. For clean semver tags the major is inferred directly without network calls.

**No version (latest):** `GetOverallLatestVersionFor` probes `/@latest` across all major versions of the fork and picks the highest.

For the default repo with no version, extension dependencies are still inspected first (existing behaviour from #445).

## Changes

- `internal/sync/sync.go` — k6-specific wrappers (`ResolveK6ModuleForVersion`, `GetOverallLatestK6Version`, `getOverallLatestK6Version`, `probeK6ModuleForVersion`, `GetLatestK6VersionFor`) replaced by generic equivalents (`ResolveModuleForVersion`, `GetOverallLatestVersionFor`, `GetLatestVersion`) that work with any module base path
- `internal/cmd/build_helper.go` — `resolveK6Repo` unified to handle both default and custom repos; `newFoundry` extracts `/vN` suffix from custom repo path and passes it as `K6MajorVersion` to k6foundry; `majorVersionSuffix` helper added
- `internal/cmd/build_helper_test.go` — new test file covering custom repo resolution
- `internal/sync/sync_internal_test.go` — tests updated to use generic functions; four new tests for `ResolveModuleForVersion` with custom base paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)