### PR TITLE
fix: escape module paths in Go proxy URLs to support uppercase repo names

### DIFF
--- a/internal/cmd/build_helper.go
+++ b/internal/cmd/build_helper.go
@@ -283,6 +283,14 @@ func (m *modules) Set(val string) error {
 // For the default repo with no explicit version, extension dependencies are
 // inspected first so their declared k6 version drives the build.
 func resolveK6Repo(ctx context.Context, opts *buildOptions) {
+	// Validate the module path early so callers get a clear error rather than
+	// a confusing failure deep in the Go toolchain. Strip any /vN suffix first
+	// since CheckPath expects a bare module path without the major-version suffix.
+	basePath, _, _ := module.SplitPathVersion(opts.k6repo)
+	if err := module.CheckPath(basePath); err != nil {
+		slog.Warn("Invalid k6 repo module path", "repo", opts.k6repo, "error", err)
+	}
+
 	// User already included a /vN suffix — trust it as-is.
 	if _, pathMajor, ok := module.SplitPathVersion(opts.k6repo); ok && pathMajor != "" {
 		slog.Debug("Using k6 repo with explicit major version suffix", "repo", opts.k6repo)

--- a/internal/cmd/build_helper.go
+++ b/internal/cmd/build_helper.go
@@ -175,11 +175,12 @@ func newFoundry(ctx context.Context, opts *buildOptions) (k6foundry.Foundry, err
 	// version so k6foundry can resolve the correct module path for non-semver versions
 	// such as "latest". For actual forks (e.g. github.com/myfork/k6/v2), set K6Repo and
 	// extract K6MajorVersion from the /vN suffix so the require path matches.
-	if strings.HasPrefix(opts.k6repo, defaultK6Repo+"/v") {
-		fopts.K6MajorVersion = opts.k6repo[len(defaultK6Repo+"/"):]
+	base, pathMajor, _ := module.SplitPathVersion(opts.k6repo)
+	if base == defaultK6Repo && pathMajor != "" {
+		fopts.K6MajorVersion = module.PathMajorPrefix(pathMajor)
 	} else if opts.k6repo != defaultK6Repo {
 		fopts.K6Repo = opts.k6repo
-		if _, pathMajor, ok := module.SplitPathVersion(opts.k6repo); ok && pathMajor != "" {
+		if pathMajor != "" {
 			fopts.K6MajorVersion = module.PathMajorPrefix(pathMajor)
 		}
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 )
 
@@ -160,7 +161,12 @@ type versionInfo struct {
 // probeVersionInfo calls /@v/<version>.info for pkg.
 // On 200 it returns the canonical version string. Any non-200 response is an error.
 func probeVersionInfo(ctx context.Context, pkg, version string) (string, error) {
-	resp, err := goProxyGet(ctx, fmt.Sprintf("/%s/@v/%s.info", pkg, version))
+	path, err := proxyPath(pkg, fmt.Sprintf("/@v/%s.info", version))
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := goProxyGet(ctx, path)
 	if err != nil {
 		return "", err
 	}
@@ -411,6 +417,17 @@ func loadModfile(dir string) (*modfile.File, error) {
 	return file, nil
 }
 
+// proxyPath builds a proxy URL path with the module path and version properly
+// escaped per the module proxy protocol (uppercase letters encoded as !lowercase).
+func proxyPath(modulePath, suffix string) (string, error) {
+	escaped, err := module.EscapePath(modulePath)
+	if err != nil {
+		return "", fmt.Errorf("invalid module path %q: %w", modulePath, err)
+	}
+
+	return "/" + escaped + suffix, nil
+}
+
 func goproxy() string {
 	proxy := os.Getenv("GOPROXY") //nolint:forbidigo
 	if len(proxy) == 0 {
@@ -421,7 +438,12 @@ func goproxy() string {
 }
 
 func getModule(ctx context.Context, pkg string, version string) (*modfile.File, error) {
-	resp, err := goProxyGet(ctx, fmt.Sprintf("/%s/@v/%s.mod", pkg, version))
+	path, err := proxyPath(pkg, fmt.Sprintf("/@v/%s.mod", version))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := goProxyGet(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +470,12 @@ func getModule(ctx context.Context, pkg string, version string) (*modfile.File, 
 }
 
 func getLatestVersion(ctx context.Context, pkg string) (string, error) {
-	resp, err := goProxyGet(ctx, fmt.Sprintf("/%s/@latest", pkg))
+	path, err := proxyPath(pkg, "/@latest")
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := goProxyGet(ctx, path)
 	if err != nil {
 		return "", err
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"golang.org/x/mod/modfile"
@@ -393,7 +392,8 @@ func resolveK6Module(ctx context.Context, opts *Options, mf *modfile.File) (modu
 // It matches go.k6.io/k6 as well as go.k6.io/k6/v2, go.k6.io/k6/v3, etc.
 func findK6Require(mf *modfile.File) (path, version string, found bool) {
 	for _, r := range mf.Require {
-		if r.Mod.Path == k6BaseModule || strings.HasPrefix(r.Mod.Path, k6BaseModule+"/v") {
+		base, _, _ := module.SplitPathVersion(r.Mod.Path)
+		if base == k6BaseModule {
 			return r.Mod.Path, r.Mod.Version, true
 		}
 	}


### PR DESCRIPTION
## Summary

When `--k6-repo` (or `XK6_K6_REPO`) points to a repository with uppercase letters in the path (e.g. `github.com/MyOrg/k6fork`), xk6's direct Go proxy calls returned 404s and silently fell back to defaults, making custom forks unusable.

## How it works

The Go module proxy protocol requires uppercase letters in module paths to be encoded using the `!` escaping scheme before they appear in URLs (`MyOrg` → `!my!org`). The Go toolchain applies this automatically, but xk6's own HTTP calls to the proxy in `internal/sync` were embedding raw module paths, so any uppercase letter caused the lookup to fail.

The fix adds a `proxyPath()` helper that applies `module.EscapePath` from `golang.org/x/mod` before constructing each proxy URL, and wires it into all three call sites (`getModule`, `getLatestVersion`, `probeVersionInfo`). A `module.CheckPath` validation is also added early in `resolveK6Repo` so an invalid module path surfaces with a clear warning rather than a cryptic failure inside the Go toolchain.

The second commit is a small cleanup along the same lines: `strings.HasPrefix` checks on module paths replaced by `module.SplitPathVersion`, which correctly parses the `/vN` suffix rather than doing substring matching.

## Changes

- `internal/sync/sync.go` — add `proxyPath()` helper using `module.EscapePath`; use it in `getModule`, `getLatestVersion`, `probeVersionInfo`; replace `strings.HasPrefix` in `findK6Require` with `module.SplitPathVersion`; drop unused `strings` import
- `internal/cmd/build_helper.go` — add `module.CheckPath` validation in `resolveK6Repo`; replace `strings.HasPrefix` + manual offset slice in `newFoundry` with `module.SplitPathVersion` + `module.PathMajorPrefix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)