### PR TITLE
Fix Broken Go Version Constraint in Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": { "version": "2.72.0" },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/devcontainers/features/go:1": { "version": "1.26.x" },
+    "ghcr.io/devcontainers/features/go:1": { "version": "1.26" },
     "ghcr.io/guiyomh/features/goreleaser:0": { "version": "2.15.4" },
     "ghcr.io/guiyomh/features/gotestsum:0": { "version": "1.12.1" },
     "ghcr.io/szkiba/devcontainer-features/gosec:1": { "version": "2.25.0" },


### PR DESCRIPTION
Fixes #482

Change the Go version constraint from `1.26.x` to `1.26` to align with the `validate.yml` workflow configuration and use a valid version specification.