### PR TITLE
Release v1.4.0

### DIFF
--- a/releases/v1.4.0.md
+++ b/releases/v1.4.0.md
@@ -1,0 +1,46 @@
+Grafana **xk6** `v1.4.0` is here! 🎉
+
+This release delivers automatic k6 major version resolution, making xk6 builds work seamlessly across k6's major versions without any manual configuration.
+
+## Features
+
+### Auto-resolve k6 major version module path ([#445](https://github.com/grafana/xk6/pull/445))
+
+When k6 moved from `go.k6.io/k6` to `go.k6.io/k6/v2`, any `xk6 build` without `--k6-repo` would fail with:
+
+```
+go.mod:5: require go.k6.io/k6: version "v1.7.1-0.20260401084312-d2c34d930734" invalid:
+  go.mod has post-v1 module path "go.k6.io/k6/v2" at revision d2c34d930734
+```
+
+xk6 now automatically determines the correct k6 module path (`go.k6.io/k6`, `go.k6.io/k6/v2`, etc.) so that builds work across major versions without requiring `--k6-repo`. The resolution strategy depends on `--k6-version`:
+
+- **No version (latest):** each extension's `go.mod` is inspected for a k6 dependency. If none is found, the Go proxy is probed across all major-version paths to find the highest published version.
+- **Clean semver tag (e.g. `v2.0.0`):** the module path is inferred directly from the major version — no network calls.
+- **SHA, branch, or pseudo-version:** a two-step proxy lookup (`.info` → `.mod`) resolves the canonical version and reads the authoritative module declaration.
+
+Pass `--verbose` / `-v` to see all proxy requests and resolution decisions in the debug output.
+
+See [docs/k6-module-resolution.md](../docs/k6-module-resolution.md) for the full algorithm reference.
+
+### Auto-resolve major version for custom k6 repo forks ([#477](https://github.com/grafana/xk6/pull/477))
+
+The same automatic resolution now applies when `--k6-repo` / `XK6_K6_REPO` points to a custom fork. xk6 probes the Go proxy to detect the correct versioned module path and appends the `/vN` suffix automatically — both the `require` directive and the `replace` path are set consistently. An explicit `/vN` suffix in the repo value is trusted as-is, skipping any proxy calls.
+
+## Bug fixes
+
+- **`build` command on Windows** ([#474](https://github.com/grafana/xk6/pull/474)): fixes a crash where the spawned `go` subprocess used `C:\Windows` as its temp directory (a write-protected location) because xk6 was launching the subprocess with a scrubbed environment. Resolves [#473](https://github.com/grafana/xk6/issues/473).
+- **Escape module paths in Go proxy URLs** ([#478](https://github.com/grafana/xk6/pull/478)): module paths containing uppercase letters (e.g. `github.com/MyOrg/k6fork`) are now correctly percent-encoded using Go's `!`-escaping scheme before being embedded in proxy URLs. Previously, uppercase paths silently fell back to defaults, making such custom forks unusable.
+
+## Dependency updates
+
+- Bumped `k6foundry` to `v0.5.2` ([#475](https://github.com/grafana/xk6/pull/475))
+- Updated `github.com/fatih/color` to `v1.19.0` ([#472](https://github.com/grafana/xk6/pull/472))
+- Updated `github.com/mattn/go-isatty` to `v0.0.21` ([#470](https://github.com/grafana/xk6/pull/470))
+- Updated `github.com/go-git/go-git/v5` to `v5.18.0` ([#468](https://github.com/grafana/xk6/pull/468))
+
+## Other changes
+
+- Transferred CODEOWNERS to `@grafana/k6-core` ([#481](https://github.com/grafana/xk6/pull/481))
+- Switched to k6's shared golangci config and lint action ([#443](https://github.com/grafana/xk6/pull/443))
+- Various CI and tooling dependency updates


### PR DESCRIPTION
Grafana **xk6** `v1.4.0` is here! 🎉

This release delivers automatic k6 major version resolution, making xk6 builds work seamlessly across k6's major versions without any manual configuration.

## Features

### Auto-resolve k6 major version module path ([#445](https://github.com/grafana/xk6/pull/445))

When k6 moved from `go.k6.io/k6` to `go.k6.io/k6/v2`, any `xk6 build` without `--k6-repo` would fail with:

```
go.mod:5: require go.k6.io/k6: version "v1.7.1-0.20260401084312-d2c34d930734" invalid:
  go.mod has post-v1 module path "go.k6.io/k6/v2" at revision d2c34d930734
```

xk6 now automatically determines the correct k6 module path (`go.k6.io/k6`, `go.k6.io/k6/v2`, etc.) so that builds work across major versions without requiring `--k6-repo`. The resolution strategy depends on `--k6-version`:

- **No version (latest):** each extension's `go.mod` is inspected for a k6 dependency. If none is found, the Go proxy is probed across all major-version paths to find the highest published version.
- **Clean semver tag (e.g. `v2.0.0`):** the module path is inferred directly from the major version — no network calls.
- **SHA, branch, or pseudo-version:** a two-step proxy lookup (`.info` → `.mod`) resolves the canonical version and reads the authoritative module declaration.

Pass `--verbose` / `-v` to see all proxy requests and resolution decisions in the debug output.

See [docs/k6-module-resolution.md](../docs/k6-module-resolution.md) for the full algorithm reference.

### Auto-resolve major version for custom k6 repo forks ([#477](https://github.com/grafana/xk6/pull/477))

The same automatic resolution now applies when `--k6-repo` / `XK6_K6_REPO` points to a custom fork. xk6 probes the Go proxy to detect the correct versioned module path and appends the `/vN` suffix automatically — both the `require` directive and the `replace` path are set consistently. An explicit `/vN` suffix in the repo value is trusted as-is, skipping any proxy calls.

## Bug fixes

- **`build` command on Windows** ([#474](https://github.com/grafana/xk6/pull/474)): fixes a crash where the spawned `go` subprocess used `C:\Windows` as its temp directory (a write-protected location) because xk6 was launching the subprocess with a scrubbed environment. Resolves [#473](https://github.com/grafana/xk6/issues/473).
- **Escape module paths in Go proxy URLs** ([#478](https://github.com/grafana/xk6/pull/478)): module paths containing uppercase letters (e.g. `github.com/MyOrg/k6fork`) are now correctly percent-encoded using Go's `!`-escaping scheme before being embedded in proxy URLs. Previously, uppercase paths silently fell back to defaults, making such custom forks unusable.

## Dependency updates

- Bumped `k6foundry` to `v0.5.2` ([#475](https://github.com/grafana/xk6/pull/475))
- Updated `github.com/fatih/color` to `v1.19.0` ([#472](https://github.com/grafana/xk6/pull/472))
- Updated `github.com/mattn/go-isatty` to `v0.0.21` ([#470](https://github.com/grafana/xk6/pull/470))
- Updated `github.com/go-git/go-git/v5` to `v5.18.0` ([#468](https://github.com/grafana/xk6/pull/468))

## Other changes

- Transferred CODEOWNERS to `@grafana/k6-core` ([#481](https://github.com/grafana/xk6/pull/481))
- Switched to k6's shared golangci config and lint action ([#443](https://github.com/grafana/xk6/pull/443))
- Various CI and tooling dependency updates