### PR TITLE
Do not require govuln to pass to test extensions

### DIFF
--- a/.github/workflows/extension-validate.yml
+++ b/.github/workflows/extension-validate.yml
@@ -229,7 +229,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    needs: ["security"]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -267,7 +266,6 @@ jobs:
   smoke:
     name: Smoke
     runs-on: ubuntu-latest
-    needs: ["security"]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
Given that govuln check catches a whole lot of stuff including stuff in k6 version that might be outside of extesnion author hands - lets keep it but not require it