### PR TITLE
Revert "chore(deps): update go toolchain directive to v1.26.3"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.k6.io/xk6
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.25.10
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
Reverts grafana/xk6#512
Keep 1.25 as minimal requirement because of CI environments