### PR TITLE
docs: Prepare release notes for v1.4.4

### DIFF
--- a/releases/v1.4.4.md
+++ b/releases/v1.4.4.md
@@ -1,0 +1,14 @@
+Grafana **xk6** `v1.4.4` is here! 🎉
+
+This release focuses on security updates and dependency upgrades.
+
+## Security fixes
+
+- Updated `golang.org/x/net` to `v0.55.0` ([#526](https://github.com/grafana/xk6/pull/526))
+- Updated `golang.org/x/crypto` to `v0.52.0` ([#525](https://github.com/grafana/xk6/pull/525))
+- Updated `github.com/go-git/go-git/v5` to `v5.19.1` ([#524](https://github.com/grafana/xk6/pull/524))
+
+## Dependency updates
+
+- Updated `goreleaser/goreleaser` to `v2.16.0` ([#529](https://github.com/grafana/xk6/pull/529))
+- Updated `cgr.dev/chainguard/go:latest-dev` Docker base image digest ([#528](https://github.com/grafana/xk6/pull/528))


### PR DESCRIPTION
Release notes for the next release (v1.4.4).

5 commits since v1.4.3, all dependency/security updates:

## Security fixes
- `golang.org/x/net` → v0.55.0 (#526)
- `golang.org/x/crypto` → v0.52.0 (#525)
- `github.com/go-git/go-git/v5` → v5.19.1 (#524)

## Dependency updates
- `goreleaser/goreleaser` → v2.16.0 (#529)
- `cgr.dev/chainguard/go:latest-dev` Docker base image digest (#528)