### PR TITLE
ci: publish Docker images to Docker Hub via GAR mirror

### DIFF
--- a/.github/workflows/liveness.yml
+++ b/.github/workflows/liveness.yml
@@ -216,7 +216,20 @@ jobs:
 
           echo "::notice::Pulling Docker image: grafana/xk6:$XK6_VERSION"
 
-          docker pull grafana/xk6:$XK6_VERSION
+          # Docker Hub publishing is async via gar-image-mirror, so the image
+          # may not be on docker.io immediately after the release job. Retry
+          # the pull until the mirror has copied it (up to ~10 minutes).
+          n=0
+          max=30
+          until docker pull "grafana/xk6:$XK6_VERSION"; do
+            n=$((n + 1))
+            if [ "$n" -ge "$max" ]; then
+              echo "::error::grafana/xk6:$XK6_VERSION not on Docker Hub after $((max * 20))s"
+              exit 1
+            fi
+            echo "::notice::Image not yet mirrored to Docker Hub; retry $n/$max in 20s"
+            sleep 20
+          done
 
           cat >> $GITHUB_STEP_SUMMARY <<END
 

--- a/.github/workflows/tooling-release.yml
+++ b/.github/workflows/tooling-release.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docker: ${{steps.configure.outputs.docker}}
-      docker-io: ${{steps.configure.outputs.docker-io}}
+      gar: ${{steps.configure.outputs.gar}}
       ghcr-io: ${{steps.configure.outputs.ghcr-io}}
     steps:
       - name: Checkout code
@@ -43,9 +43,9 @@ jobs:
             echo "docker=true" >> $GITHUB_OUTPUT
             echo "ghcr-io=true" >> $GITHUB_OUTPUT
           fi
-          if yq -r '.dockers[].image_templates[]' .goreleaser.y*ml | grep -q docker.io ; then
+          if yq -r '.dockers[].image_templates[]' .goreleaser.y*ml | grep -q us-docker.pkg.dev ; then
             echo "docker=true" >> $GITHUB_OUTPUT
-            echo "docker-io=true" >> $GITHUB_OUTPUT
+            echo "gar=true" >> $GITHUB_OUTPUT
           fi
       - name: Summary
         env:
@@ -54,7 +54,7 @@ jobs:
           GORELEASER_VERSION: ${{ inputs.goreleaser-version }}
           K6_VERSIONS: ${{ join(fromJSON(inputs.k6-versions),' ') }}
           GHCR_IO: ${{ steps.configure.outputs.ghcr-io }}
-          DOCKER_IO: ${{ steps.configure.outputs.docker-io }}
+          GAR: ${{ steps.configure.outputs.gar }}
         run: |
           cat >> $GITHUB_STEP_SUMMARY <<END
 
@@ -73,8 +73,8 @@ jobs:
           if [ -n "${GHCR_IO}" ]; then
             echo "Push Docker image to ghcr.io" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ -n "${DOCKER_IO}" ]; then
-            echo "Push Docker image to docker.io" >> $GITHUB_STEP_SUMMARY
+          if [ -n "${GAR}" ]; then
+            echo "Push Docker image to GAR (mirrored to docker.io/grafana)" >> $GITHUB_STEP_SUMMARY
           fi
 
   security:
@@ -158,9 +158,11 @@ jobs:
           set -e
           bats $BATS | tee -a $GITHUB_STEP_SUMMARY
 
-      - name: Login to Docker Hub
-        if: ${{ needs.config.outputs.docker-io == 'true' }}
-        uses: grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7 # dockerhub-login/v1.0.4
+      - name: Login to GAR
+        if: ${{ needs.config.outputs.gar == 'true' }}
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
 
       - name: Login to GitHub Packages
         if: ${{ needs.config.outputs.ghcr-io == 'true' }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,9 @@ version: 2
 
 env:
   - IMAGE=grafana/{{.ProjectName}}
+  # Docker Hub publishing goes through the GAR image mirror (gar-image-mirror
+  # copies us-docker.pkg.dev/.../dockerhub-xk6-prod-mirror -> docker.io/grafana).
+  - MIRROR_IMAGE=us-docker.pkg.dev/grafanalabs-global/dockerhub-{{.ProjectName}}-prod-mirror/{{.ProjectName}}
 
 before:
   hooks:
@@ -75,10 +78,10 @@ dockers:
     use: buildx
     extra_files: ["docker-entrypoint.sh"]
     image_templates:
-      - 'docker.io/{{ .Env.IMAGE }}:{{ replace .Tag "v" "" }}-amd64'
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}-amd64"
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-amd64"
-      - "docker.io/{{ .Env.IMAGE }}:latest-amd64"
+      - '{{ .Env.MIRROR_IMAGE }}:{{ replace .Tag "v" "" }}-amd64'
+      - "{{ .Env.MIRROR_IMAGE }}:{{ .Major }}-amd64"
+      - "{{ .Env.MIRROR_IMAGE }}:{{ .Major }}.{{ .Minor }}-amd64"
+      - "{{ .Env.MIRROR_IMAGE }}:latest-amd64"
 
       - 'ghcr.io/{{ .Env.IMAGE }}:{{ replace .Tag "v" "" }}-amd64'
       - "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}-amd64"
@@ -100,10 +103,10 @@ dockers:
     use: buildx
     extra_files: ["docker-entrypoint.sh"]
     image_templates:
-      - 'docker.io/{{ .Env.IMAGE }}:{{ replace .Tag "v" "" }}-arm64'
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}-arm64"
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-arm64"
-      - "docker.io/{{ .Env.IMAGE }}:latest-arm64"
+      - '{{ .Env.MIRROR_IMAGE }}:{{ replace .Tag "v" "" }}-arm64'
+      - "{{ .Env.MIRROR_IMAGE }}:{{ .Major }}-arm64"
+      - "{{ .Env.MIRROR_IMAGE }}:{{ .Major }}.{{ .Minor }}-arm64"
+      - "{{ .Env.MIRROR_IMAGE }}:latest-arm64"
 
       - 'ghcr.io/{{ .Env.IMAGE }}:{{ replace .Tag "v" "" }}-arm64'
       - "ghcr.io/{{ .Env.IMAGE }}:{{ .Major }}-arm64"
@@ -120,25 +123,25 @@ dockers:
 
 docker_manifests:
   - id: tag
-    name_template: 'docker.io/{{ .Env.IMAGE }}:{{ replace .Tag "v" "" }}'
+    name_template: '{{ .Env.MIRROR_IMAGE }}:{{ replace .Tag "v" "" }}'
     image_templates:
-      - 'docker.io/{{ .Env.IMAGE }}:{{ replace .Tag "v" "" }}-amd64'
-      - 'docker.io/{{ .Env.IMAGE }}:{{ replace .Tag "v" "" }}-arm64'
+      - '{{ .Env.MIRROR_IMAGE }}:{{ replace .Tag "v" "" }}-amd64'
+      - '{{ .Env.MIRROR_IMAGE }}:{{ replace .Tag "v" "" }}-arm64'
   - id: major
-    name_template: "docker.io/{{ .Env.IMAGE }}:{{ .Major }}"
+    name_template: "{{ .Env.MIRROR_IMAGE }}:{{ .Major }}"
     image_templates:
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}-amd64"
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}-arm64"
+      - "{{ .Env.MIRROR_IMAGE }}:{{ .Major }}-amd64"
+      - "{{ .Env.MIRROR_IMAGE }}:{{ .Major }}-arm64"
   - id: major-minor
-    name_template: "docker.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}"
+    name_template: "{{ .Env.MIRROR_IMAGE }}:{{ .Major }}.{{ .Minor }}"
     image_templates:
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-amd64"
-      - "docker.io/{{ .Env.IMAGE }}:{{ .Major }}.{{ .Minor }}-arm64"
+      - "{{ .Env.MIRROR_IMAGE }}:{{ .Major }}.{{ .Minor }}-amd64"
+      - "{{ .Env.MIRROR_IMAGE }}:{{ .Major }}.{{ .Minor }}-arm64"
   - id: latest
-    name_template: "docker.io/{{ .Env.IMAGE }}:latest"
+    name_template: "{{ .Env.MIRROR_IMAGE }}:latest"
     image_templates:
-      - "docker.io/{{ .Env.IMAGE }}:latest-amd64"
-      - "docker.io/{{ .Env.IMAGE }}:latest-arm64"
+      - "{{ .Env.MIRROR_IMAGE }}:latest-amd64"
+      - "{{ .Env.MIRROR_IMAGE }}:latest-arm64"
 
   - id: tag-ghcr
     name_template: 'ghcr.io/{{ .Env.IMAGE }}:{{ replace .Tag "v" "" }}'


### PR DESCRIPTION
## What

Migrate Docker Hub publishing to the [GAR image mirror](https://github.com/grafana/deployment_tools/blob/master/docs/platform/gar-image-mirror.md). The shared Docker Hub write token used by CI has been disabled; images must now be pushed to a repo-scoped GAR staging repo with a short-lived OIDC token, and the `gar-image-mirror` service copies them to `docker.io/grafana/xk6`.

```
release workflow (OIDC) → GAR (dockerhub-xk6-prod-mirror) → gar-image-mirror (ops) → docker.io/grafana/xk6
```

## Changes

- **`.goreleaser.yaml`** — add `MIRROR_IMAGE` env (`us-docker.pkg.dev/grafanalabs-global/dockerhub-xk6-prod-mirror/xk6`) and route every `docker.io/...` image + manifest template through it. `ghcr.io` images are unchanged.
- **`.github/workflows/tooling-release.yml`** — replace the `dockerhub-login` step with `login-to-gar` (`registry: us-docker.pkg.dev`), and update the config-job auto-detection to key off the GAR registry instead of `docker.io`. `id-token: write` is already granted on the release job.
- **`.github/workflows/liveness.yml`** — the `docker` liveness job pulls `grafana/xk6:<version>` straight after release. Docker Hub publishing is now **async**, so the pull is wrapped in a bounded retry (~10 min) to wait for the mirror to copy the image.

## Depends on

GAR mirror provisioning + mapping in deployment_tools: grafana/deployment_tools#604694 (must be `atlantis apply`'d and the mapping rolled out via Flux before the next release).

## Verifying

After the next tagged release: image appears in GAR, then on `docker.io/grafana/xk6:<tag>` shortly after; liveness docker job passes.