### PR TITLE
docs: Prepare release notes for v1.4.5

### DIFF
--- a/releases/v1.4.5.md
+++ b/releases/v1.4.5.md
@@ -1,0 +1,22 @@
+Grafana **xk6** `v1.4.5` is here! 🎉
+
+> [!NOTE]
+> `v1.4.4` was tagged but never produced release artifacts. The shared Docker Hub publishing token was disabled as part of a security hardening, which failed the release job before any binaries or images were built. `v1.4.5` re-releases all of the `v1.4.4` changes through the new GAR-based publishing pipeline, together with the fixes below.
+
+This release focuses on the publishing pipeline, security updates, and dependency upgrades.
+
+## CI / publishing
+
+- Publish Docker images to Docker Hub via the GAR image mirror, using short-lived OIDC tokens instead of the disabled shared Docker Hub token ([#536](https://github.com/grafana/xk6/pull/536))
+
+## Security fixes
+
+- Updated `go` toolchain directive to `v1.25.11` ([#535](https://github.com/grafana/xk6/pull/535))
+- Updated `golang.org/x/net` to `v0.55.0` ([#526](https://github.com/grafana/xk6/pull/526))
+- Updated `golang.org/x/crypto` to `v0.52.0` ([#525](https://github.com/grafana/xk6/pull/525))
+- Updated `github.com/go-git/go-git/v5` to `v5.19.1` ([#524](https://github.com/grafana/xk6/pull/524))
+
+## Dependency updates
+
+- Updated `goreleaser/goreleaser` to `v2.16.0` ([#529](https://github.com/grafana/xk6/pull/529))
+- Updated `cgr.dev/chainguard/go:latest-dev` Docker base image digest ([#528](https://github.com/grafana/xk6/pull/528))


### PR DESCRIPTION
## What

Release notes for `v1.4.5`.

`v1.4.4` was tagged but never produced release artifacts — the shared Docker Hub publishing token was disabled (security hardening) and the release job failed before any binaries or images were built. `v1.4.5` re-releases the `v1.4.4` changes through the new GAR-based publishing pipeline (#536), plus the go toolchain security bump (#535).

## Folded in from v1.4.4

Security: #524, #525, #526 · Dependencies: #528, #529

## New in v1.4.5

- #536 — publish Docker images to Docker Hub via the GAR image mirror
- #535 — go toolchain directive to v1.25.11 [security]