### PR TITLE
ci: fix GAR login detection in release workflow

### DIFF
--- a/.github/workflows/tooling-release.yml
+++ b/.github/workflows/tooling-release.yml
@@ -43,7 +43,10 @@ jobs:
             echo "docker=true" >> $GITHUB_OUTPUT
             echo "ghcr-io=true" >> $GITHUB_OUTPUT
           fi
-          if yq -r '.dockers[].image_templates[]' .goreleaser.y*ml | grep -q us-docker.pkg.dev ; then
+          # GAR image templates reference the registry via the MIRROR_IMAGE
+          # env var, so the literal registry host is not present in the
+          # rendered template strings here -- match the env var instead.
+          if yq -r '.dockers[].image_templates[]' .goreleaser.y*ml | grep -q MIRROR_IMAGE ; then
             echo "docker=true" >> $GITHUB_OUTPUT
             echo "gar=true" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Problem

The `v1.4.5` release failed: the `login-to-gar` step was skipped, so the GoReleaser publish had no Docker Hub auth.

Root cause: the config job detects the GAR push target by grepping the goreleaser `.dockers[].image_templates[]` for the registry host `us-docker.pkg.dev`. In #536 the image templates were switched to reference the registry through the `{{ .Env.MIRROR_IMAGE }}` env var, so the literal host string is no longer in the template strings — `yq ... | grep -q us-docker.pkg.dev` matched nothing, `gar` was never set to `true`, and the login step's `if` guard skipped it.

## Fix

Match the `MIRROR_IMAGE` env var in the rendered templates instead of the registry host. Verified `yq -r '.dockers[].image_templates[]' .goreleaser.yaml | grep -q MIRROR_IMAGE` matches (8 templates).

## Follow-up

Re-tag `v1.4.5` once merged to produce the release artifacts.