### PR TITLE
fix(docker): bump gosec to v2.27.1 and govulncheck to v1.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       # #region inputs
       go-version: "1.25.x"
       goreleaser-version: "2.16.0"
-      k6-versions: '["v1.2.3","v1.0.0"]'
+      k6-versions: '["v2.0.0"]'
       bats: ./.github/release.bats
       # #endregion inputs
   liveness:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,6 @@ jobs:
       go-versions: '["1.25.x","1.26.x"]'
       goreleaser-version: "2.16.0"
       platforms: '["ubuntu-latest", "windows-latest", "macos-latest"]'
-      k6-versions: '["v1.2.3","v1.0.0"]'
+      k6-versions: '["v2.0.0"]'
       bats: .github/validate.bats
       # #endregion inputs

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 ARG GO_IMAGE=cgr.dev/chainguard/go:latest-dev@sha256:3aa88c8d4864448fb936d22850ab922476b914c7ed1834612284aea25fa5edc3
 
 # Define global build arguments for the tools to install from source
-ARG GOSEC_VERSION=v2.26.1
-ARG GOVULNCHECK_VERSION=v1.1.4
+ARG GOSEC_VERSION=v2.27.1
+ARG GOVULNCHECK_VERSION=v1.3.0
 
 # ==========================================
 # STAGE 1: Builder

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -3,8 +3,8 @@
 ARG GO_IMAGE=cgr.dev/chainguard/go:latest-dev@sha256:3aa88c8d4864448fb936d22850ab922476b914c7ed1834612284aea25fa5edc3
 
 # Define global build arguments for the tools to install from source
-ARG GOSEC_VERSION=v2.26.1
-ARG GOVULNCHECK_VERSION=v1.1.4
+ARG GOSEC_VERSION=v2.27.1
+ARG GOVULNCHECK_VERSION=v1.3.0
 
 # ==========================================
 # STAGE 1: Builder (for govulncheck and gosec)


### PR DESCRIPTION
## Problem

The Grafana vulnerability dashboard (grype) reports Critical/High CVEs on the published xk6 image. The vulnerable code is **not in xk6** — it's in the **gosec binary** baked into the image.

gosec **v2.26.1** is compiled against `golang.org/x/crypto v0.50.0` and `golang.org/x/net v0.53.0`, which carry advisories **GO-2026-5005…5033**. grype reads the embedded Go module metadata of the binary and flags them.

This is why it was hard to reproduce locally: the advisories are a recent batch, so a stale local grype DB (or scanning only the `xk6` binary / source, which build from patched deps) shows nothing — only a current-DB scan of the embedded gosec binary surfaces them.

## Fix

| binary | before | after | grype |
|---|---|---|---|
| gosec | v2.26.1 (x/crypto v0.50.0, x/net v0.53.0) | **v2.27.1** (x/crypto v0.52.0, x/net v0.55.0) | Critical/High → **none** |
| govulncheck | v1.1.4 | **v1.3.0** | clean → clean |

Applied to **both** `Dockerfile` and `Dockerfile.goreleaser`.

Verified with grype v0.114.0: gosec v2.26.1 → many Critical/High; gosec v2.27.1 and govulncheck v1.3.0 → *No vulnerabilities found*.

## Also: fix k6 version for xk6-it integration tests

The Validate run surfaced a separate, pre-existing breakage: `validate.bats` / `release.bats` build a k6 binary with the **latest xk6-it release** (resolved in `helpers.bash`). xk6-it **v1.4.0** migrated to `go.k6.io/k6/v2` and now requires **k6 v2.0.0**, so building it against k6 v1.x (`v1.2.3` / `v1.0.0`) fails.

Set `k6-versions` to `["v2.0.0"]` in both `validate.yml` and `release.yml` (release.bats had the same latent failure).