### PR TITLE
fix(build): workaround VCS stamping failure in Go 1.25 temp builds

### DIFF
--- a/internal/cmd/build_helper.go
+++ b/internal/cmd/build_helper.go
@@ -48,7 +48,7 @@ const (
 	defaultCgo          = 0
 	defaultRaceDetector = 0
 	defaultSkipCleanup  = 0
-	defaultBuildFlags   = "-trimpath,-ldflags=-s -w"
+	defaultBuildFlags   = "-trimpath,-ldflags=-s -w,-buildvcs=false"
 )
 
 var nonGoEnvToCopy = []string{ //nolint:gochecknoglobals


### PR DESCRIPTION
Closes #542

## Summary

Adds `-buildvcs=false` to the default `--build-flags` as a temporary workaround for the VCS stamping failure described in #542.

This is not a long-term fix — the proper solution is to make the temporary build directory satisfy Go's VCS provenance requirements. See #542 for details.

## Test Plan

- [ ] `xk6 build --with github.com/grafana/xk6-faker` succeeds on Go 1.25
- [ ] Existing tests pass