### PR TITLE
ci: swap k6 lint action for the k6-ci composite at v0.3.0

### DIFF
--- a/.github/workflows/tooling-validate.yml
+++ b/.github/workflows/tooling-validate.yml
@@ -132,7 +132,12 @@ jobs:
           go mod verify
 
       - name: Run golangci-lint with k6 ruleset
-        uses: grafana/k6/.github/actions/lint@1646ca06eeb44c5e495426f1226c9a4bc241d741 # master
+        # `ref` is passed explicitly because this workflow is itself a
+        # workflow_call: action_ref doesn't propagate through nested
+        # workflow_call -> composite action chains.
+        uses: grafana/k6-ci/.github/actions/lint@143ec80c1678ae96a54b82389ea862d4748c27e1 # v0.3.0
+        with:
+          ref: 143ec80c1678ae96a54b82389ea862d4748c27e1 # v0.3.0
 
   smoke:
     name: Smoke


### PR DESCRIPTION
## What

In \`tooling-validate.yml\`, replace the \`grafana/k6/.github/actions/lint@<sha>\` step with \`grafana/k6-ci/.github/actions/lint@143ec80c… # v0.3.0\`. The \`ref:\` input is passed explicitly because this workflow runs via \`workflow_call\` and \`github.action_ref\` doesn't propagate cleanly through nested \`workflow_call\` → composite action chains.

## Why

The lint action is being removed from \`grafana/k6\`; the canonical home is now \`grafana/k6-ci\`. v0.3.0 of k6-ci exposes the lint logic as a composite action specifically for direct callers like this workflow.

## Downstream impact

\`tooling-validate.yml\` isn't called directly by any repo — it's invoked by \`xk6/validate.yml\`, which is consumed by ~13 xk6 extension repos via \`workflow_call\`:

\`\`\`
grafana/xk6-client-prometheus-remote
grafana/xk6-example
grafana/xk6-faker
grafana/xk6-grafana-alerting
grafana/xk6-icmp
grafana/xk6-mqtt
grafana/xk6-output-example
grafana/xk6-sql
grafana/xk6-ssh
grafana/xk6-subcommand-example
grafana/xk6-subcommand-explore
grafana/xk6-subcommand-httpbin
grafana/xk6-tcp
\`\`\`

When those extensions bump their \`grafana/xk6/.github/workflows/validate.yml@<ref>\` pin past this PR, two things change for their lint runs:

1. \`.golangci.yml\` comes from \`grafana/k6-ci@v0.3.0\` instead of \`grafana/k6@master\`. The k6-ci base ruleset is a strict subset of k6's — it drops the \`afero\` forbid pattern and the \`js/modules/k6/{browser,html,http}/\`-path-specific exclusions that aren't relevant outside k6. At most a relaxation.
2. The golangci-lint binary version is read from line 1 of that file (currently \`v2.10.1\`), not from k6's config.

Extensions that want their own tweaks can drop a \`.golangci.patch\` at their repo root — k6-ci's lint action applies it before invoking golangci-lint.

## Notes

- The deps check (\`go mod tidy && go mod verify\`) earlier in this job is unchanged. It's a slightly different shape from k6-ci's \`deps\` composite action and replacing it would be a separate, blast-radius-heavy change.
- The \`uses:\` line and the \`ref:\` input value are pinned to the same SHA, and the \`# v0.3.0\` Renovate-style comment is present on both. Renovate will keep them in sync once the customManager in \`grafana/grafana-renovate-config\` (already in place via grafana-renovate-config#90) sees the workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)