### PR TITLE
Enable Renovate auto-merge for trusted reps

### DIFF
--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -1,0 +1,14 @@
+name: Auto-approve Renovate
+on:
+  schedule:
+    - cron: '1 * * * *'
+  workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: read
+  id-token: write
+jobs:
+  approve:
+    uses: grafana/k6-ci/.github/workflows/auto-approve-renovate.yml@9477260e6838640d56c28aa95bcbf9a884ab21f3 # k6-ci#44 merge commit

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json"
+    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json",
+    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-automerge.json"
   ],
   "customManagers": [
     {
@@ -32,7 +33,9 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/\\.github/workflows/.+\\.yml$/"],
+      "managerFilePatterns": [
+        "/\\.github/workflows/.+\\.yml$/"
+      ],
       "matchStrings": [
         "GORELEASER_VERSION:\\s+[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
       ],
@@ -42,7 +45,9 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/\\.github/workflows/.+\\.yml$/"],
+      "managerFilePatterns": [
+        "/\\.github/workflows/.+\\.yml$/"
+      ],
       "matchStrings": [
         "GOVULNCHECK_VERSION:\\s+[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
       ],
@@ -52,7 +57,9 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/\\.github/workflows/.+\\.yml$/"],
+      "managerFilePatterns": [
+        "/\\.github/workflows/.+\\.yml$/"
+      ],
       "matchStrings": [
         "GOSEC_VERSION:\\s+[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
       ],
@@ -62,7 +69,9 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/\\.github/workflows/.+\\.yml$/"],
+      "managerFilePatterns": [
+        "/\\.github/workflows/.+\\.yml$/"
+      ],
       "matchStrings": [
         "bats-version:\\s+[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
       ],
@@ -72,7 +81,9 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/\\.devcontainer/devcontainer\\.json$/"],
+      "managerFilePatterns": [
+        "/\\.devcontainer/devcontainer\\.json$/"
+      ],
       "matchStrings": [
         "\"golangciLintVersion\":\\s+\"(?<currentValue>[0-9.]+)\""
       ],
@@ -82,7 +93,9 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/\\.devcontainer/devcontainer\\.json$/"],
+      "managerFilePatterns": [
+        "/\\.devcontainer/devcontainer\\.json$/"
+      ],
       "matchStrings": [
         "ghcr\\.io/guiyomh/features/goreleaser:\\d+\":[^}]+\"version\":\\s+\"(?<currentValue>[0-9.]+)\""
       ],
@@ -92,7 +105,9 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/\\.devcontainer/devcontainer\\.json$/"],
+      "managerFilePatterns": [
+        "/\\.devcontainer/devcontainer\\.json$/"
+      ],
       "matchStrings": [
         "ghcr\\.io/szkiba/devcontainer-features/gosec:\\d+\":[^}]+\"version\":\\s+\"(?<currentValue>[0-9.]+)\""
       ],
@@ -102,7 +117,9 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/\\.devcontainer/devcontainer\\.json$/"],
+      "managerFilePatterns": [
+        "/\\.devcontainer/devcontainer\\.json$/"
+      ],
       "matchStrings": [
         "ghcr\\.io/szkiba/devcontainer-features/govulncheck:\\d+\":[^}]+\"version\":\\s+\"(?<currentValue>[0-9.]+)\""
       ],
@@ -112,7 +129,9 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/\\.devcontainer/devcontainer\\.json$/"],
+      "managerFilePatterns": [
+        "/\\.devcontainer/devcontainer\\.json$/"
+      ],
       "matchStrings": [
         "ghcr\\.io/szkiba/devcontainer-features/bats:\\d+\":[^}]+\"version\":\\s+\"(?<currentValue>[0-9.]+)\""
       ],
@@ -124,31 +143,56 @@
   "packageRules": [
     {
       "description": "Update workflow tooling versions (golangci-lint, goreleaser)",
-      "matchManagers": ["custom.regex"],
-      "matchDepNames": ["golangci/golangci-lint", "goreleaser/goreleaser"],
-      "matchFileNames": [".github/workflows/**", "docs/workflows/README.md"],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "golangci/golangci-lint",
+        "goreleaser/goreleaser"
+      ],
+      "matchFileNames": [
+        ".github/workflows/**",
+        "docs/workflows/README.md"
+      ],
       "groupName": "workflow tooling",
-      "extends": ["schedule:weekly"]
+      "extends": [
+        "schedule:weekly"
+      ]
     },
     {
       "description": "Update devcontainer tooling versions (golangci-lint, goreleaser)",
-      "matchManagers": ["custom.regex"],
-      "matchDepNames": ["golangci/golangci-lint", "goreleaser/goreleaser"],
-      "matchFileNames": [".devcontainer/**"],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "golangci/golangci-lint",
+        "goreleaser/goreleaser"
+      ],
+      "matchFileNames": [
+        ".devcontainer/**"
+      ],
       "groupName": "workflow tooling",
-      "extends": ["schedule:weekly"]
+      "extends": [
+        "schedule:weekly"
+      ]
     },
     {
       "description": "Update devcontainer security tools (gosec, govulncheck)",
-      "matchManagers": ["custom.regex"],
+      "matchManagers": [
+        "custom.regex"
+      ],
       "matchDepNames": [
         "securego/gosec",
         "golang.org/x/vuln/cmd/govulncheck",
         "bats-core/bats-core"
       ],
-      "matchFileNames": [".devcontainer/**"],
+      "matchFileNames": [
+        ".devcontainer/**"
+      ],
       "groupName": "workflow tooling",
-      "extends": ["schedule:weekly"]
+      "extends": [
+        "schedule:weekly"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What?

Enables the k6 Renovate auto-merge approval flow, replicating the setup proven in [k6-pilot](https://github.com/grafana/k6-pilot).

- Extends `renovate.json` with [the shared preset](https://github.com/grafana/grafana-renovate-config/blob/main/presets/k6/k6-engine-automerge.json) for auto-merging trusted deps.
- Adds [a workflow](https://github.com/grafana/k6-ci/blob/main/.github/workflows/auto-approve-renovate.yml) that approves those PRs once all CI checks pass.

## Why?

To reduce the team's toll on Renovate PRs by 50%.

## Related PR(s)/Issue(s)

- grafana/k6-pilot#86
- grafana/k6-ci#44