### PR TITLE
Check generated docs in validation

### DIFF
--- a/.github/workflows/tooling-validate.yml
+++ b/.github/workflows/tooling-validate.yml
@@ -134,6 +134,33 @@ jobs:
       - name: Run golangci-lint with k6 ruleset
         uses: grafana/k6/.github/actions/lint@1646ca06eeb44c5e495426f1226c9a4bc241d741 # master
 
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    needs: ["config"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Go ${{ inputs.go-version }}
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "${{ inputs.go-version }}"
+          check-latest: true
+
+      - name: Install documentation tools
+        run: |
+          mkdir -p "${RUNNER_TEMP}/go/bin"
+          echo "${RUNNER_TEMP}/go/bin" >> "${GITHUB_PATH}"
+          GOBIN="${RUNNER_TEMP}/go/bin" go install github.com/szkiba/mdcode@v0.2.0
+
+      - name: Check generated documentation
+        run: |
+          make doc
+          git diff --exit-code
+
   smoke:
     name: Smoke
     runs-on: ubuntu-latest

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -25,9 +25,9 @@ The [`validate.bats`](../../.github/validate.bats) script is passed as the integ
 ```yaml file=../../.github/workflows/validate.yml region=inputs
       go-version: "1.26.x"
       go-versions: '["1.25.x","1.26.x"]'
-      goreleaser-version: "2.13.3"
+      goreleaser-version: "2.16.0"
       platforms: '["ubuntu-latest", "windows-latest", "macos-latest"]'
-      k6-versions: '["v1.2.3","v1.0.0"]'
+      k6-versions: '["v2.0.0"]'
       bats: .github/validate.bats
 ```
 
@@ -48,8 +48,8 @@ The [`release.bats`](../../.github/release.bats) script is passed as the integra
 
 ```yaml file=../../.github/workflows/release.yml region=inputs
       go-version: "1.25.x"
-      goreleaser-version: "2.13.3"
-      k6-versions: '["v1.2.3","v1.0.0"]'
+      goreleaser-version: "2.16.0"
+      k6-versions: '["v2.0.0"]'
       bats: ./.github/release.bats
 ```
 
@@ -79,6 +79,8 @@ The **Tooling Validate** ([`tooling-validate.yml`](../../.github/workflows/tooli
   --no-config --presets bugs --enable gofmt
   ```
   In case of an error, the workflow will stop with an error.
+
+- **Docs**: Regenerate documentation and fail if generated files are not up to date.
 
 - **Smoke**: Run short Go tests (`-short` flag) on single platform and single go version. In case of an error, the workflow will stop with an error. The role of this job is to quickly stop the workflow in case of trivial test errors, preventing slower tests from running on multiple platforms using multiple go versions.
 


### PR DESCRIPTION
Fixes #467.

## What changed

- Add a `Docs` job to the tooling validation workflow.
- The job installs `mdcode`, runs `make doc`, and fails if generated files are not up to date.
- Refresh stale generated workflow documentation snippets that already differed from the current workflow inputs.

## Verification

- `git diff --check`
- `go test -short -timeout 2m ./internal/cmd`

Notes: I could not run `make doc` directly on this Windows machine because `make` is not installed. Running the underlying `mdcode` command and the full Go test suite were also blocked locally by Windows Application Control when Go produced temporary executables. The new workflow job runs on `ubuntu-latest`, where `make` and generated Go executables are expected to work normally.