### PR TITLE
Bump gosec build version to v2.28.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG GO_IMAGE=cgr.dev/chainguard/go:latest-dev@sha256:9037a8af6e7da42863009baf03973773f28b90402a4118b561a8510bc8deb529
 
 # Define global build arguments for the tools to install from source
-ARG GOSEC_VERSION=v2.27.1
+ARG GOSEC_VERSION=v2.28.0
 ARG GOVULNCHECK_VERSION=v1.3.0
 
 # ==========================================


### PR DESCRIPTION
Bump `GOSEC_VERSION` v2.27.1 → v2.28.0.