### PR TITLE
Add Dockerfile to Renovate's version tracking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,8 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/\\.github/workflows/.+\\.yml$/",
-        "/Dockerfile$/"
+        "/Dockerfile$/",
+        "/Dockerfile\\.goreleaser$/"
       ],
       "matchStrings": [
         "GOVULNCHECK_VERSION[:=]\\s*[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
@@ -60,7 +61,8 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/\\.github/workflows/.+\\.yml$/",
-        "/Dockerfile$/"
+        "/Dockerfile$/",
+        "/Dockerfile\\.goreleaser$/"
       ],
       "matchStrings": [
         "GOSEC_VERSION[:=]\\s*[\"']?(?<currentValue>v?[0-9.]+)[\"']?"

--- a/renovate.json
+++ b/renovate.json
@@ -46,10 +46,11 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/\\.github/workflows/.+\\.yml$/"
+        "/\\.github/workflows/.+\\.yml$/",
+        "/Dockerfile$/"
       ],
       "matchStrings": [
-        "GOVULNCHECK_VERSION:\\s+[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
+        "GOVULNCHECK_VERSION[:=]\\s*[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "golang.org/x/vuln/cmd/govulncheck",
@@ -58,10 +59,11 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/\\.github/workflows/.+\\.yml$/"
+        "/\\.github/workflows/.+\\.yml$/",
+        "/Dockerfile$/"
       ],
       "matchStrings": [
-        "GOSEC_VERSION:\\s+[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
+        "GOSEC_VERSION[:=]\\s*[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "securego/gosec",


### PR DESCRIPTION
`GOSEC_VERSION`/`GOVULNCHECK_VERSION` customManagers only watched `.github/workflows/*.yml`. The Dockerfile `ARG` pins — what actually ships in the image — were never in scope, and drifted (see #577, #579). Adds both `Dockerfile` and `Dockerfile.goreleaser` (the one the release pipeline actually uses) to both managers, and widens the regex to match `ARG NAME=value` alongside the existing `NAME: value` form. Tested both patterns locally.
