### PR TITLE
Bump gosec version in release Dockerfile

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -3,7 +3,7 @@
 ARG GO_IMAGE=cgr.dev/chainguard/go:latest-dev@sha256:9037a8af6e7da42863009baf03973773f28b90402a4118b561a8510bc8deb529
 
 # Define global build arguments for the tools to install from source
-ARG GOSEC_VERSION=v2.27.1
+ARG GOSEC_VERSION=v2.28.0
 ARG GOVULNCHECK_VERSION=v1.3.0
 
 # ==========================================


### PR DESCRIPTION
Same fix as #577, but on the Dockerfile that actually matters: `.goreleaser.yaml` builds the published image from `Dockerfile.goreleaser`, not `Dockerfile`. #577 only touched the latter, so v1.4.10 still shipped with the vulnerable gosec@v2.27.1 — confirmed live, still 2 days over SLO.

Verified via local build: gosec now pulls x/net v0.57.0 / x/text v0.40.0.
