### PR TITLE
Replace go-git usage with system Git

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/ctrf-io/go-ctrf-json-reporter v0.1.0
 	github.com/fatih/color v1.19.0
 	github.com/go-enry/go-license-detector/v4 v4.3.1
-	github.com/go-git/go-git/v5 v5.19.2
 	github.com/go-task/slim-sprig/v3 v3.0.0
 	github.com/goreleaser/fileglob v1.4.0
 	github.com/grafana/k6foundry v0.5.2
@@ -36,6 +35,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
+	github.com/go-git/go-git/v5 v5.19.2 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/internal/cmd/adjust.go
+++ b/internal/cmd/adjust.go
@@ -52,9 +52,9 @@ func adjustCmd() *cobra.Command {
 	return cmd
 }
 
-func probeModuleFromGitURL(opts *adjustOptions) bool {
+func probeModuleFromGitURL(ctx context.Context, opts *adjustOptions) bool {
 	if len(opts.Module) == 0 {
-		gitURL, err := getGitURL(opts.directory)
+		gitURL, err := getGitURL(ctx, opts.directory)
 		if err != nil {
 			slog.Info("Missing git origin URL, skipping customization", "directory", opts.directory)
 
@@ -74,7 +74,7 @@ func probeModuleFromGitURL(opts *adjustOptions) bool {
 
 func probeDescriptionFromGitURL(ctx context.Context, opts *adjustOptions) bool {
 	if len(opts.Description) == 0 {
-		gitURL, err := getGitURL(opts.directory)
+		gitURL, err := getGitURL(ctx, opts.directory)
 		if err != nil {
 			slog.Info("Missing git origin URL, skipping customization", "directory", opts.directory)
 
@@ -110,7 +110,7 @@ func adjustRunE(ctx context.Context, opts *adjustOptions) error {
 		return nil
 	}
 
-	if !probeModuleFromGitURL(opts) {
+	if !probeModuleFromGitURL(ctx, opts) {
 		return nil
 	}
 

--- a/internal/cmd/new_helpers.go
+++ b/internal/cmd/new_helpers.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	giturls "github.com/chainguard-dev/git-urls"
-	"github.com/go-git/go-git/v5"
+	gitcmd "go.k6.io/xk6/internal/git"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 )
@@ -32,22 +32,8 @@ func getModulePath(dir string) (string, error) {
 	return mod.Module.Mod.Path, nil
 }
 
-func getGitURL(dir string) (string, error) {
-	repo, err := git.PlainOpen(dir)
-	if err != nil {
-		return "", err
-	}
-
-	remote, err := repo.Remote("origin")
-	if err != nil {
-		return "", err
-	}
-
-	if len(remote.Config().URLs) == 0 {
-		return "", git.ErrMissingURL
-	}
-
-	return remote.Config().URLs[0], nil
+func getGitURL(ctx context.Context, dir string) (string, error) {
+	return gitcmd.RemoteURL(ctx, dir, "origin")
 }
 
 func parseGitURL(gitURL string) (string, string, string, error) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,86 @@
+// Package git provides the small subset of Git operations used by xk6.
+package git
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Clone clones url into dir using the Git executable available on PATH.
+func Clone(ctx context.Context, url, dir string) error {
+	parent := filepath.Dir(dir)
+	name := filepath.Base(dir)
+
+	_, err := run(ctx, parent, "clone", "--", url, name)
+
+	return err
+}
+
+// RemoteURL returns the URL configured for remote on dir.
+func RemoteURL(ctx context.Context, dir, remote string) (string, error) {
+	out, err := run(ctx, dir, "remote", "get-url", remote)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(out), nil
+}
+
+// IsWorktree verifies that dir is inside a non-bare Git worktree.
+func IsWorktree(ctx context.Context, dir string) error {
+	out, err := run(ctx, dir, "rev-parse", "--is-inside-work-tree")
+	if err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(out) != "true" {
+		return fmt.Errorf("directory is not a Git worktree")
+	}
+
+	return nil
+}
+
+// Tags returns all tag names in dir.
+func Tags(ctx context.Context, dir string) ([]string, error) {
+	out, err := run(ctx, dir, "for-each-ref", "--format=%(refname:strip=2)", "refs/tags")
+	if err != nil {
+		return nil, err
+	}
+
+	var tags []string
+	for _, tag := range strings.Split(out, "\n") {
+		tag = strings.TrimSuffix(tag, "\r")
+		if tag != "" {
+			tags = append(tags, tag)
+		}
+	}
+
+	return tags, nil
+}
+
+// Checkout checks out ref in detached HEAD mode in dir.
+func Checkout(ctx context.Context, dir, ref string) error {
+	_, err := run(ctx, dir, "checkout", "--quiet", "--detach", ref)
+
+	return err
+}
+
+func run(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- arguments are passed directly without a shell
+	cmd.Dir = dir
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(out))
+		if detail != "" {
+			return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, detail)
+		}
+
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+
+	return string(out), nil
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -51,7 +51,7 @@ func Tags(ctx context.Context, dir string) ([]string, error) {
 	}
 
 	var tags []string
-	for _, tag := range strings.Split(out, "\n") {
+	for tag := range strings.SplitSeq(out, "\n") {
 		tag = strings.TrimSuffix(tag, "\r")
 		if tag != "" {
 			tags = append(tags, tag)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -69,7 +69,15 @@ func Checkout(ctx context.Context, dir, ref string) error {
 }
 
 func run(ctx context.Context, dir string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- arguments are passed directly without a shell
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		return "", fmt.Errorf(
+			"git is required but was not found on PATH; "+
+				"install Git and ensure it is available in PATH: %w", err,
+		)
+	}
+
+	cmd := exec.CommandContext(ctx, gitPath, args...) // #nosec G204 -- arguments are passed directly without a shell
 	cmd.Dir = dir
 
 	out, err := cmd.CombinedOutput()

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,98 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRepositoryOperations(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not installed")
+	}
+
+	ctx := context.Background()
+	source := t.TempDir()
+	t.Setenv("GIT_AUTHOR_NAME", "xk6 tests")
+	t.Setenv("GIT_AUTHOR_EMAIL", "xk6@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "xk6 tests")
+	t.Setenv("GIT_COMMITTER_EMAIL", "xk6@example.com")
+	runGit(t, source, "init")
+	runGit(t, source, "config", "user.email", "xk6@example.com")
+	runGit(t, source, "config", "user.name", "xk6 tests")
+	runGit(t, source, "config", "commit.gpgsign", "false")
+
+	if err := os.WriteFile(filepath.Join(source, "README.md"), []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "add", "README.md")
+	runGit(t, source, "commit", "-m", "initial")
+	runGit(t, source, "tag", "v1.0.0")
+
+	if err := os.WriteFile(filepath.Join(source, "README.md"), []byte("v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, source, "add", "README.md")
+	runGit(t, source, "commit", "-m", "second")
+	runGit(t, source, "tag", "v2.0.0")
+	runGit(t, source, "tag", "not-a-version")
+
+	clone := filepath.Join(t.TempDir(), "clone")
+	if err := Clone(ctx, source, clone); err != nil {
+		t.Fatal(err)
+	}
+
+	remote, err := RemoteURL(ctx, clone, "origin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remote != source {
+		t.Fatalf("remote URL = %q, want %q", remote, source)
+	}
+
+	if err := IsWorktree(ctx, clone); err != nil {
+		t.Fatal(err)
+	}
+
+	tags, err := Tags(ctx, clone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(tags, "v1.0.0") || !contains(tags, "v2.0.0") || !contains(tags, "not-a-version") {
+		t.Fatalf("tags = %v, want all test tags", tags)
+	}
+
+	if err := Checkout(ctx, clone, "v1.0.0"); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(filepath.Join(clone, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(content)) != "v1" {
+		t.Fatalf("README after checkout = %q, want v1", content)
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -25,14 +26,14 @@ func TestRepositoryOperations(t *testing.T) {
 	runGit(t, source, "config", "user.name", "xk6 tests")
 	runGit(t, source, "config", "commit.gpgsign", "false")
 
-	if err := os.WriteFile(filepath.Join(source, "README.md"), []byte("v1\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(source, "README.md"), []byte("v1\n"), 0o644); err != nil { //nolint:forbidigo
 		t.Fatal(err)
 	}
 	runGit(t, source, "add", "README.md")
 	runGit(t, source, "commit", "-m", "initial")
 	runGit(t, source, "tag", "v1.0.0")
 
-	if err := os.WriteFile(filepath.Join(source, "README.md"), []byte("v2\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(source, "README.md"), []byte("v2\n"), 0o644); err != nil { //nolint:forbidigo
 		t.Fatal(err)
 	}
 	runGit(t, source, "add", "README.md")
@@ -68,7 +69,7 @@ func TestRepositoryOperations(t *testing.T) {
 	if err := Checkout(ctx, clone, "v1.0.0"); err != nil {
 		t.Fatal(err)
 	}
-	content, err := os.ReadFile(filepath.Join(clone, "README.md"))
+	content, err := os.ReadFile(filepath.Join(clone, "README.md")) //nolint:forbidigo
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,19 +79,13 @@ func TestRepositoryOperations(t *testing.T) {
 }
 
 func contains(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(values, want)
 }
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(context.Background(), "git", args...)
 	cmd.Dir = dir
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -78,6 +78,19 @@ func TestRepositoryOperations(t *testing.T) {
 	}
 }
 
+func TestGitNotFound(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := Tags(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("Tags() error = nil, want missing Git error")
+	}
+
+	if !strings.Contains(err.Error(), "git is required but was not found on PATH") {
+		t.Fatalf("Tags() error = %q, want missing Git message", err)
+	}
+}
+
 func contains(values []string, want string) bool {
 	return slices.Contains(values, want)
 }

--- a/internal/lint/checker_git.go
+++ b/internal/lint/checker_git.go
@@ -3,11 +3,11 @@ package lint
 import (
 	"context"
 
-	"github.com/go-git/go-git/v5"
+	gitcmd "go.k6.io/xk6/internal/git"
 )
 
-func checkerGit(_ context.Context, dir string) *checkResult {
-	_, err := git.PlainOpen(dir)
+func checkerGit(ctx context.Context, dir string) *checkResult {
+	err := gitcmd.IsWorktree(ctx, dir)
 	if err != nil {
 		return checkError(err)
 	}

--- a/internal/lint/checker_versions.go
+++ b/internal/lint/checker_versions.go
@@ -3,11 +3,9 @@ package lint
 import (
 	"context"
 	"sort"
-	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
+	gitcmd "go.k6.io/xk6/internal/git"
 )
 
 type version struct {
@@ -15,33 +13,19 @@ type version struct {
 	tag    string
 }
 
-func checkerVersions(_ context.Context, dir string) *checkResult {
-	repo, err := git.PlainOpen(dir)
+func checkerVersions(ctx context.Context, dir string) *checkResult {
+	tags, err := gitcmd.Tags(ctx, dir)
 	if err != nil {
 		return checkError(err)
 	}
-
-	iter, err := repo.Tags()
-	if err != nil {
-		return checkError(err)
-	}
-
-	const tagPrefix = "refs/tags/"
 
 	versions := make([]*version, 0)
 
-	err = iter.ForEach(func(ref *plumbing.Reference) error {
-		tag := strings.TrimPrefix(ref.Name().String(), tagPrefix)
-
+	for _, tag := range tags {
 		ver, err := semver.NewVersion(tag)
 		if err == nil {
 			versions = append(versions, &version{semver: ver, tag: tag})
 		}
-
-		return nil
-	})
-	if err != nil {
-		return checkError(err)
 	}
 
 	if len(versions) == 0 {

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -13,20 +13,18 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
+	gitcmd "go.k6.io/xk6/internal/git"
 )
 
 // Scaffold scaffolds a new k6 extension based on provided sample and actual sample parameters.
 func Scaffold(ctx context.Context, sample *Sample, actual *Sample, parentDir string) error {
 	dir := filepath.Join(parentDir, path.Base(actual.Module))
 
-	repo, err := git.PlainCloneContext(ctx, dir, false, &git.CloneOptions{URL: sample.Repository})
-	if err != nil {
+	if err := gitcmd.Clone(ctx, sample.Repository, dir); err != nil {
 		return err
 	}
 
-	latest, err := getLatest(repo)
+	latest, err := getLatest(ctx, dir)
 	if err != nil {
 		return err
 	}
@@ -34,8 +32,7 @@ func Scaffold(ctx context.Context, sample *Sample, actual *Sample, parentDir str
 	if len(latest) == 0 {
 		slog.Warn("No releases, the default branch will be used!", "repo", sample.Repository)
 	} else {
-		err = checkout(repo, latest)
-		if err != nil {
+		if err := checkout(ctx, dir, latest); err != nil {
 			return err
 		}
 	}
@@ -53,24 +50,19 @@ func Adjust(dir string, sample *Sample, actual *Sample) error {
 	return customize(dir, newReplacer(sample, actual))
 }
 
-func getLatest(repo *git.Repository) (plumbing.ReferenceName, error) {
-	iter, err := repo.Tags()
+func getLatest(ctx context.Context, dir string) (string, error) {
+	tags, err := gitcmd.Tags(ctx, dir)
 	if err != nil {
 		return "", err
 	}
 
 	versions := make([]*semver.Version, 0)
 
-	err = iter.ForEach(func(ref *plumbing.Reference) error {
-		ver, err := semver.NewVersion(ref.Name().Short())
+	for _, tag := range tags {
+		ver, err := semver.NewVersion(tag)
 		if err == nil {
 			versions = append(versions, ver)
 		}
-
-		return nil
-	})
-	if err != nil {
-		return "", err
 	}
 
 	if len(versions) == 0 {
@@ -81,16 +73,11 @@ func getLatest(repo *git.Repository) (plumbing.ReferenceName, error) {
 		return versions[j].LessThan(versions[i])
 	})
 
-	return plumbing.NewTagReferenceName(versions[0].Original()), nil
+	return versions[0].Original(), nil
 }
 
-func checkout(repo *git.Repository, name plumbing.ReferenceName) error {
-	wt, err := repo.Worktree()
-	if err != nil {
-		return err
-	}
-
-	return wt.Checkout(&git.CheckoutOptions{Branch: name})
+func checkout(ctx context.Context, dir, name string) error {
+	return gitcmd.Checkout(ctx, dir, name)
 }
 
 func cleanup(dir string) error {


### PR DESCRIPTION
## What

Replace xk6 direct use of go-git with the system git executable.

This adds a small internal Git wrapper and updates scaffolding, adjustment, and lint operations to use it for:

- cloning repositories
- reading remotes
- checking worktrees
- listing tags
- checking out revisions

## Why

This removes the need for xk6 to implement Git operations through the Go library and makes its Git behavior consistent with the Git installation used by users and CI.

This also addresses an issue where xk6 lint version checks were not working correctly on bare repositories for unknown reasons. The problem was raised in the k6registry discussion:

https://github.com/grafana/k6registry/pull/375#discussion_r3805885005

Using the system Git commands should make tag and repository handling more transparent and easier to diagnose.