### PR TITLE
fix(docker): resolve CVEs in the xk6 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 # Base image pinned to Chainguard's latest-dev stream to ensure zero CVEs.
-# Note: This specific digest resolves to Go 1.26.x
-ARG GO_IMAGE=cgr.dev/chainguard/go:latest-dev@sha256:9037a8af6e7da42863009baf03973773f28b90402a4118b561a8510bc8deb529
+# Note: This specific digest resolves to Go 1.27.x
+ARG GO_IMAGE=cgr.dev/chainguard/go:latest-dev@sha256:9eb676cef7df351a8511e7b11ff3822778b884dfde8ddadba81d43a33d24253f
 
 # Define global build arguments for the tools to install from source
 ARG GOSEC_VERSION=v2.28.0
-ARG GOVULNCHECK_VERSION=v1.3.0
+ARG GOVULNCHECK_VERSION=v1.7.0
+
+# Patched releases of transitive dependencies that gosec and govulncheck still
+# pin to vulnerable versions (CVE-2026-56864, CVE-2026-56865, GHSA-hrxh-6v49-42gf)
+ARG XMOD_VERSION=v0.40.0
+ARG GRPC_VERSION=v1.83.1
 
 # ==========================================
 # STAGE 1: Builder
@@ -14,6 +19,8 @@ FROM --platform=$BUILDPLATFORM ${GO_IMAGE} AS builder
 # Pull global ARGs into this stage's scope
 ARG GOSEC_VERSION
 ARG GOVULNCHECK_VERSION
+ARG XMOD_VERSION
+ARG GRPC_VERSION
 
 # Docker automatically injects these during multi-platform builds
 ARG TARGETOS
@@ -32,12 +39,18 @@ ENV GOSEC_VERSION=${GOSEC_VERSION} \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH}
 
-# Install security tools (Go hides them in the GOPATH when cross-compiling)
-RUN go install -ldflags="-s -w" golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
-RUN go install -ldflags="-s -w" github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}
-
-# Fish the installed tools out of the GOPATH and move them to our working dir
-RUN find $(go env GOPATH)/bin -type f -exec mv {} /build/ \;
+# Build the security tools from a throwaway module. 'go install tool@version'
+# would honour the tools' own go.mod pins, which still reference vulnerable
+# releases of golang.org/x/mod and google.golang.org/grpc; a scratch module lets
+# us force the patched ones in. Building instead of installing also drops the
+# binaries straight into /build, so there is no GOPATH to fish them out of.
+RUN mkdir /tools && cd /tools && \
+    go mod init xk6-tools && \
+    go get golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
+           github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION} && \
+    go get golang.org/x/mod@${XMOD_VERSION} google.golang.org/grpc@${GRPC_VERSION} && \
+    go build -ldflags="-s -w" -o /build/govulncheck golang.org/x/vuln/cmd/govulncheck && \
+    go build -ldflags="-s -w" -o /build/gosec github.com/securego/gosec/v2/cmd/gosec
 
 # Compile xk6 and fixids statically
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o xk6 -trimpath .

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,10 +1,15 @@
 # Base image pinned to Chainguard's latest-dev stream to ensure zero CVEs.
-# Note: This specific digest resolves to Go 1.26.x
-ARG GO_IMAGE=cgr.dev/chainguard/go:latest-dev@sha256:9037a8af6e7da42863009baf03973773f28b90402a4118b561a8510bc8deb529
+# Note: This specific digest resolves to Go 1.27.x
+ARG GO_IMAGE=cgr.dev/chainguard/go:latest-dev@sha256:9eb676cef7df351a8511e7b11ff3822778b884dfde8ddadba81d43a33d24253f
 
 # Define global build arguments for the tools to install from source
 ARG GOSEC_VERSION=v2.28.0
-ARG GOVULNCHECK_VERSION=v1.3.0
+ARG GOVULNCHECK_VERSION=v1.7.0
+
+# Patched releases of transitive dependencies that gosec and govulncheck still
+# pin to vulnerable versions (CVE-2026-56864, CVE-2026-56865, GHSA-hrxh-6v49-42gf)
+ARG XMOD_VERSION=v0.40.0
+ARG GRPC_VERSION=v1.83.1
 
 # ==========================================
 # STAGE 1: Builder (for govulncheck and gosec)
@@ -14,6 +19,8 @@ FROM --platform=$BUILDPLATFORM ${GO_IMAGE} AS builder
 # Pull global ARGs into this stage's scope
 ARG GOSEC_VERSION
 ARG GOVULNCHECK_VERSION
+ARG XMOD_VERSION
+ARG GRPC_VERSION
 
 # Docker automatically injects these during multi-platform builds
 ARG TARGETOS
@@ -31,15 +38,19 @@ ENV GOSEC_VERSION=${GOSEC_VERSION} \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH}
 
-# Build both security tools directly from source
-
-# 1. Install without GOBIN because cross-compilation can cause issues with the Go toolchain's handling of the GOPATH/bin directory.
-#    Instead, we'll find the binaries in their default location after installation.
-RUN go install -ldflags="-s -w" golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
-RUN go install -ldflags="-s -w" github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}
-
-# 2. Fish the compiled binaries out of the GOPATH and move them to our /build folder
-RUN find $(go env GOPATH)/bin -type f -exec mv {} /build/ \;
+# Build both security tools from a throwaway module. 'go install tool@version'
+# would honour the tools' own go.mod pins, which still reference vulnerable
+# releases of golang.org/x/mod and google.golang.org/grpc; a scratch module lets
+# us force the patched ones in. Building instead of installing also drops the
+# binaries straight into /build, sidestepping the GOPATH/bin handling that makes
+# cross-compilation awkward.
+RUN mkdir /tools && cd /tools && \
+    go mod init xk6-tools && \
+    go get golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} \
+           github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION} && \
+    go get golang.org/x/mod@${XMOD_VERSION} google.golang.org/grpc@${GRPC_VERSION} && \
+    go build -ldflags="-s -w" -o /build/govulncheck golang.org/x/vuln/cmd/govulncheck && \
+    go build -ldflags="-s -w" -o /build/gosec github.com/securego/gosec/v2/cmd/gosec
 
 # ==========================================
 # STAGE 2: Final Runtime

--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,34 @@
       "versioningTemplate": "semver"
     },
     {
+      "description": "Transitive dependency overrides for the security tools built into the image",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/Dockerfile$/",
+        "/Dockerfile\\.goreleaser$/"
+      ],
+      "matchStrings": [
+        "XMOD_VERSION[:=]\\s*[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
+      ],
+      "datasourceTemplate": "go",
+      "depNameTemplate": "golang.org/x/mod",
+      "versioningTemplate": "semver"
+    },
+    {
+      "description": "Transitive dependency overrides for the security tools built into the image",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/Dockerfile$/",
+        "/Dockerfile\\.goreleaser$/"
+      ],
+      "matchStrings": [
+        "GRPC_VERSION[:=]\\s*[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
+      ],
+      "datasourceTemplate": "go",
+      "depNameTemplate": "google.golang.org/grpc",
+      "versioningTemplate": "semver"
+    },
+    {
       "customType": "regex",
       "managerFilePatterns": [
         "/\\.github/workflows/.+\\.yml$/"


### PR DESCRIPTION
Fixes the scanner findings reported in #585.

trivy reported 31 findings (25 HIGH) and grype 46 matches in
`grafana/xk6:1.4.11`, from three separate causes.

## Changes

Identical edits in `Dockerfile` and `Dockerfile.goreleaser`:

- **Base digest bumped.** The pinned digest shipped Go 1.26.5, busybox
  1.37.0-r61 and OpenSSL 3.6.3-r3. The new one ships Go 1.27.0, busybox
  1.38.0-r1 and OpenSSL 3.6.3-r5, clearing all 8 OS findings and all 16 stdlib
  findings.
- **`GOVULNCHECK_VERSION` v1.3.0 -> v1.7.0.** `GOSEC_VERSION` stays at v2.28.0,
  which is already the latest release.
- **The security tools are now built from a throwaway module** rather than
  installed with `go install tool@version`, which honours each tool's own
  go.mod pins. At their latest releases both still pin a vulnerable
  `golang.org/x/mod` (fix is in v0.40.0), and gosec also a vulnerable
  `google.golang.org/grpc`, so a version bump alone cannot clear those 5
  findings and the patched versions have to be forced in via new
  `XMOD_VERSION` and `GRPC_VERSION` args. Building rather than installing also
  writes target-arch binaries straight to `/build`, which retires the
  `find $(go env GOPATH)/bin ... -exec mv` step that worked around
  cross-compilation.

`renovate.json` gains custom managers for the two new pins, so they do not
drift the way `ARG GO_IMAGE` did.

## Result

Built and scanned on both architectures: **trivy 2, grype 0** (from 31 / 46).

```
<image> (wolfi 20230201)   : 0
usr/local/bin/fixids       : 0
usr/local/bin/gosec        : 1   GO-2026-5932  no fix
usr/local/bin/govulncheck  : 0
usr/local/bin/xk6          : 1   GO-2026-5932  no fix
```

Both remaining findings are `GO-2026-5932`, `golang.org/x/crypto/openpgp` being
unmaintained, reached via the go-git dependency chain. No fixed version exists;
clearing it needs either an upstream drop of openpgp or a `.trivyignore`
decision, so it is left as is here.

## Verification

Also checked in the built image: runs as uid 1000, `fixids` keeps its setuid
bit, `go1.27.0`, `git` and `cc` present, and both an extension build
(`xk6 build --with github.com/grafana/xk6-faker` producing a working
`k6 v2.1.0` with the extension registered) and a `CGO_ENABLED=1` compile
succeed as the non-root user. `Dockerfile.goreleaser` builds to a byte-identical
image.

Note: `ARG GO_IMAGE` is still not tracked by Renovate, which is why the digest
went stale in the first place. Deciding whether Renovate should track it, or
whether the digest pin should give way to plain `latest-dev`, is left to a
follow-up.
