### PR TITLE
smoke: Replace --no-summary with --summary-mode=disabled.

### DIFF
--- a/internal/lint/checker_smoke.go
+++ b/internal/lint/checker_smoke.go
@@ -43,7 +43,7 @@ func checkerSmoke(ctx context.Context, dir string) *checkResult {
 		return checkFailed("no smoke test file found")
 	}
 
-	cmd := exec.CommandContext(ctx, exe, "run", "--no-usage-report", "--no-summary", "--quiet", filename) // #nosec G204
+	cmd := exec.CommandContext(ctx, exe, "run", "--no-usage-report", "--summary-mode=disabled", "--quiet", filename) // #nosec G204
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
smoke: Replace `--no-summary` with `--summary-mode=disabled`.

- closes #594 